### PR TITLE
Add necessary Info.plist key for Camera permission requests

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -41,5 +41,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSCameraUsageDescription</key>
+	<string>Cashew needs to use the Camera to scan QR codes</string>
 </dict>
 </plist>


### PR DESCRIPTION
This adds the necessary informational blurb about why we want access
to the phone camera. Without this, it crashes on iOS.

See: https://flutter.dev/docs/cookbook/plugins/picture-using-camera