### PR TITLE
Add pedantic linter with Google default settings

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:pedantic/analysis_options.yaml

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,7 +32,7 @@ class MainPage extends StatefulWidget {
 }
 
 class _MainPageState extends State<MainPage> {
-  Wallet wallet = new Wallet("todo");
+  Wallet wallet = Wallet('todo');
 
   @override
   Widget build(BuildContext context) {
@@ -42,9 +42,9 @@ class _MainPageState extends State<MainPage> {
         appBar: AppBar(
           title: TabBar(
             tabs: [
-              Tab(icon: Text("Send")),
-              Tab(icon: Text("Receive")),
-              Tab(icon: Text("Balance")),
+              Tab(icon: Text('Send')),
+              Tab(icon: Text('Receive')),
+              Tab(icon: Text('Balance')),
             ],
           ),
         ),

--- a/lib/tabs/balance.dart
+++ b/lib/tabs/balance.dart
@@ -14,8 +14,8 @@ class BalanceTab extends StatelessWidget {
       child: Column(
         children: [
           ListTile(
-            title: const Text("Balance"),
-            subtitle: Text("in satoshis"),
+            title: const Text('Balance'),
+            subtitle: Text('in satoshis'),
           ),
           Padding(
             padding: const EdgeInsets.all(16.0),
@@ -34,7 +34,7 @@ class BalanceTab extends StatelessWidget {
       child: Column(
         children: [
           ListTile(
-            title: const Text("History"),
+            title: const Text('History'),
           )
         ],
       ),

--- a/lib/tabs/receive.dart
+++ b/lib/tabs/receive.dart
@@ -16,7 +16,7 @@ class ReceiveTab extends StatelessWidget {
     final manualCard = Card(
         child: Column(children: [
           ListTile(
-            title: const Text("Text Address"),
+            title: const Text('Text Address'),
           ),
           Padding(
               padding: const EdgeInsets.all(16.0),
@@ -31,7 +31,7 @@ class ReceiveTab extends StatelessWidget {
     final qrCard = Card(
       child: Column(children: [
         ListTile(
-          title: const Text("QR Address"),
+          title: const Text('QR Address'),
         ),
         QrImage(data: address, version: QrVersions.auto)
       ]),

--- a/lib/tabs/send.dart
+++ b/lib/tabs/send.dart
@@ -69,7 +69,7 @@ class SendWidget extends StatelessWidget {
           children: [
             Expanded(
                 child: TextField(
-              controller: TextEditingController(text: this.qrText),
+              controller: TextEditingController(text: qrText),
               decoration: InputDecoration(
                   border: OutlineInputBorder(), hintText: 'Enter an address'),
             )),

--- a/lib/wallet.dart
+++ b/lib/wallet.dart
@@ -1,12 +1,12 @@
 class Wallet {
-  Wallet(String walletPath) {}
+  Wallet(String walletPath);
 
   int balanceSatoshis() {
     return 1000;
   }
 
   String getAddress() {
-    return "bchtest:dsajkdsaadfghfgfhhggjkhgjhjghjbhjk";
+    return 'bchtest:dsajkdsaadfghfgfhhggjkhgjhjghjbhjk';
   }
 
   void send(String address, int satoshis) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -80,7 +80,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0-nullsafety.4"
   path:
     dependency: transitive
     description:
@@ -88,6 +88,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0-nullsafety.1"
+  pedantic:
+    dependency: "direct dev"
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.9.2"
   qr:
     dependency: transitive
     description:
@@ -127,7 +134,7 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0-nullsafety.2"
   stream_channel:
     dependency: transitive
     description:
@@ -171,5 +178,5 @@ packages:
     source: hosted
     version: "2.1.0-nullsafety.3"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
+  dart: ">=2.10.0-110 <=2.11.0-213.1.beta"
   flutter: ">=1.10.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  pedantic: ^1.9.2
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
and apply the fixes it complained about (unnecessar new,
prefer single quotes, use ; instead of {} for empty constructor and don't
prefix member with this except to avoid shadowing)