### PR TITLE
Add support for encoding and decoding base32 strings

### DIFF
--- a/lib/bitcoincash/src/encoding/base32.dart
+++ b/lib/bitcoincash/src/encoding/base32.dart
@@ -1,0 +1,204 @@
+import 'dart:core';
+import 'dart:collection';
+
+import '../exceptions.dart';
+
+// Charset for converting to base32
+const charset = [
+  'q',
+  'p',
+  'z',
+  'r',
+  'y',
+  '9',
+  'x',
+  '8',
+  'g',
+  'f',
+  '2',
+  't',
+  'v',
+  'd',
+  'w',
+  '0',
+  's',
+  '3',
+  'j',
+  'n',
+  '5',
+  '4',
+  'k',
+  'h',
+  'c',
+  'e',
+  '6',
+  'm',
+  'u',
+  'a',
+  '7',
+  'l',
+];
+
+// Charset for converting from base32
+const reversedCharset = [
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  15,
+  -1,
+  10,
+  17,
+  21,
+  20,
+  26,
+  30,
+  7,
+  5,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  29,
+  -1,
+  24,
+  13,
+  25,
+  9,
+  8,
+  23,
+  -1,
+  18,
+  22,
+  31,
+  27,
+  19,
+  -1,
+  1,
+  0,
+  3,
+  16,
+  11,
+  28,
+  12,
+  14,
+  6,
+  4,
+  2,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  29,
+  -1,
+  24,
+  13,
+  25,
+  9,
+  8,
+  23,
+  -1,
+  18,
+  22,
+  31,
+  27,
+  19,
+  -1,
+  1,
+  0,
+  3,
+  16,
+  11,
+  28,
+  12,
+  14,
+  6,
+  4,
+  2,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1
+];
+
+/// ToBase32 converts an input byte array into a base32 string.  It expects the
+/// byte array to be 5-bit packed.
+String toBase32(List<int> input) {
+  final buffer = StringBuffer();
+
+  for (final i in input) {
+    if (i < 0 || i >= charset.length) {
+      throw AddressFormatException('Illegal value $i');
+    }
+    buffer.write(charset[i]);
+  }
+  return buffer.toString();
+}
+
+/// FromBase32 takes a string in base32 format and returns a byte array that is
+/// 5-bit packed.
+List<int> fromBase32(String input) {
+  var result = <int>[];
+
+  for (final c in input.runes) {
+    if (c >= reversedCharset.length) {
+      throw AddressFormatException('Illegal value $c');
+    }
+    final val = reversedCharset[c];
+    if (val == -1) {
+      throw AddressFormatException('invalid base32 input string');
+    }
+    result.add(val);
+  }
+  return result;
+}

--- a/lib/bitcoincash/src/encoding/base32_test.dart
+++ b/lib/bitcoincash/src/encoding/base32_test.dart
@@ -1,0 +1,31 @@
+import 'package:test/test.dart';
+import 'package:dartz/dartz.dart';
+
+import 'base32.dart';
+
+void main() {
+  test('can encode to base32', () async {
+    final base32encoded = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+
+    var address = toBase32(iota(32).toList());
+    expect(address, base32encoded);
+  });
+
+  test('can decode base32', () async {
+    final base32encoded = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+
+    var address = fromBase32(base32encoded);
+
+    expect(address, iota(32).toList());
+  });
+
+  test('can encode and decode', () async {
+    var runes = List<int>.from(iota(32).toList());
+    runes.shuffle();
+
+    var encoded = toBase32(runes);
+    var decoded = fromBase32(encoded);
+
+    expect(decoded, runes);
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -148,6 +148,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.8"
+  dartz:
+    dependency: "direct main"
+    description:
+      name: dartz
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.9.2"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   sprintf: ^4.0.2
   unorm_dart: ^0.1.1
   buffer: ^1.0.6
+  dartz: ^0.9.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Add basic support for encoding and decoding base32 strings in support
of adding CashAddress support in the future.