### PR TITLE
Implement ConvertBits function in Dart

### DIFF
--- a/lib/bitcoincash/src/encoding/converbits_test.dart
+++ b/lib/bitcoincash/src/encoding/converbits_test.dart
@@ -1,0 +1,15 @@
+import 'dart:ffi';
+
+import 'package:test/test.dart';
+
+import 'convertbits.dart';
+
+void main() {
+  test('can convert back and forth between 8 and 5 bit format', () async {
+    final inputArray = [255];
+    var newBits = ConvertBits(8, 5, inputArray, true);
+    expect(newBits, [31, 28]);
+    var reconverted = ConvertBits(5, 8, newBits, false);
+    expect(reconverted, inputArray);
+  });
+}

--- a/lib/bitcoincash/src/encoding/convertbits.dart
+++ b/lib/bitcoincash/src/encoding/convertbits.dart
@@ -1,0 +1,35 @@
+import 'dart:core';
+
+// ConvertBits takes a byte array as `input`, and converts it from `frombits`
+// bit representation to a `tobits` bit representation, while optionally
+// padding it.  ConvertBits returns the new representation and a bool
+// indicating that the output was not truncated.
+List<int> ConvertBits(int frombits, int tobits, List<int> input, bool pad) {
+  if (frombits > 8) {
+    return null;
+  }
+
+  var acc = 0;
+  var bits = 0;
+  var out = <int>[];
+  //(input.length * frombits ~/ tobits);
+
+  var maxv = (1 << tobits) - 1;
+  var max_acc = (1 << (frombits + tobits - 1)) - 1;
+  for (var element in input) {
+    acc = ((acc << frombits) | (element)) & max_acc;
+    bits += frombits;
+    while (bits >= tobits) {
+      bits -= tobits;
+      var v = (acc >> bits) & maxv;
+      out.add(v);
+    }
+  }
+
+  // We have remaining bits to encode so we do pad.
+  if (pad && bits > 0) {
+    out.add(((acc << (tobits - bits)) & maxv));
+  }
+
+  return out;
+}


### PR DESCRIPTION
In order to encode and decode CashAddr BCH addresses we need a function
which will convert an array into various bit formats. The `ConvertBits`
function enables converting back and forth between multiple bit limited
arrays. (e.g. 5 and 8 for base32 encodings);