### PR TITLE
Fix pass at the scaffold of a websocket-based electrum client

### DIFF
--- a/examples/electrum.dart
+++ b/examples/electrum.dart
@@ -1,0 +1,34 @@
+import 'package:cashew/electrum/rpc.dart';
+import 'package:cashew/bitcoincash/bitcoincash.dart';
+import 'package:hex/hex.dart';
+import 'package:pointycastle/digests/sha256.dart';
+
+String toElectrumScriptHash(String address) {
+  final p2pkhBuilder = P2PKHLockBuilder(Address(address));
+  final script = p2pkhBuilder.getScriptPubkey();
+  final scriptHash = SHA256Digest().process(script.buffer).toList();
+  return HEX.encode(scriptHash.reversed.toList());
+}
+
+const bitcoinABCAddress =
+    'bitcoincash:qqeht8vnwag20yv8dvtcrd4ujx09fwxwsqqqw93w88';
+
+void main() async {
+  final electrumClient = ElectrumClient();
+  await electrumClient.connect(Uri.parse('ws://51.79.81.158:50003'));
+
+  List<Object> unspent = await electrumClient
+      .blockchainScripthashListunspent(toElectrumScriptHash(bitcoinABCAddress));
+  print(unspent[0]);
+
+  final res = await electrumClient.blockchainScripthashSubscribe(
+      toElectrumScriptHash(bitcoinABCAddress), (params) {
+    print(params.toString());
+  });
+  print(res.toString());
+
+// Wait 120 seconds before quitting.
+  await Future.delayed(Duration(seconds: 120));
+
+  electrumClient.dispose();
+}

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -2,3 +2,4 @@ import 'package:flutter/material.dart';
 
 const cardElevation = 6.0;
 const cardPadding = EdgeInsets.all(12.0);
+const electrumUrl = 'ws://electrum.bitcoincash.org';

--- a/lib/electrum/rpc.dart
+++ b/lib/electrum/rpc.dart
@@ -1,0 +1,183 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:async';
+
+import 'package:json_annotation/json_annotation.dart';
+
+part 'rpc.g.dart';
+
+class UnhandledElectrumMessage implements Exception {
+  String cause;
+  String message;
+
+  UnhandledElectrumMessage(this.cause, this.message);
+}
+
+class UnknownElectrumError implements Exception {
+  String cause;
+  String message;
+
+  UnknownElectrumError(this.cause, this.message);
+}
+
+@JsonSerializable()
+class RPCRequest {
+  @JsonKey(disallowNullValue: true)
+  final String jsonrpc = '2.0';
+  @JsonKey(disallowNullValue: true)
+  final String method;
+  @JsonKey(includeIfNull: true)
+  final int id;
+  @JsonKey(includeIfNull: true)
+  final Object params;
+
+  RPCRequest(this.method, {this.id, this.params});
+  factory RPCRequest.fromJson(Map<String, dynamic> json) =>
+      _$RPCRequestFromJson(json);
+  Map<String, dynamic> toJson() => _$RPCRequestToJson(this);
+}
+
+class RequestConverter extends Converter<Map<String, dynamic>, RPCRequest> {
+  @override
+  RPCRequest convert(input) {
+    return RPCRequest.fromJson(input);
+  }
+}
+
+@JsonSerializable()
+class Error {
+  @JsonKey(disallowNullValue: true)
+  final int code;
+  @JsonKey(disallowNullValue: true)
+  final String message;
+  @JsonKey(includeIfNull: true)
+  final Object data;
+
+  Error(this.code, this.message, {this.data});
+  factory Error.fromJson(Map<String, dynamic> json) => _$ErrorFromJson(json);
+  Map<String, dynamic> toJson() => _$ErrorToJson(this);
+}
+
+@JsonSerializable()
+class RPCResponse {
+  @JsonKey(disallowNullValue: true)
+  final String jsonrpc = '2.0';
+  @JsonKey(includeIfNull: true)
+  final Object result;
+  @JsonKey(includeIfNull: true)
+  final Error error;
+  @JsonKey(includeIfNull: true)
+  final int id;
+  @JsonKey(includeIfNull: true)
+  final String method;
+  @JsonKey(includeIfNull: true)
+  final List<Object> params;
+
+  RPCResponse(this.result, {this.id, this.error, this.method, this.params});
+  factory RPCResponse.fromJson(Map<String, dynamic> json) =>
+      _$RPCResponseFromJson(json);
+  Map<String, dynamic> toJson() => _$RPCResponseToJson(this);
+}
+
+typedef ResponseHandler = void Function(RPCResponse response);
+typedef SubscriptionHandler = void Function(List<Object> result);
+
+class JSONRPCWebsocket {
+  WebSocket rpcSocket;
+  Map<int, ResponseHandler> outstandingRequests = {};
+  Map<String, SubscriptionHandler> subscriptions = {};
+  var currentRequestId = 0;
+
+  JSONRPCWebsocket();
+
+  void connect(Uri address) async {
+    rpcSocket = await WebSocket.connect(address.toString());
+    rpcSocket.listen((dynamic data) {
+      Map<String, dynamic> jsonResult = jsonDecode(data);
+      final response = RPCResponse.fromJson(jsonResult);
+      if (response.id == null && response.method == null) {
+        throw UnhandledElectrumMessage('Missing response handler', data);
+        return;
+      }
+      if (outstandingRequests.containsKey(response.id)) {
+        final handler = outstandingRequests[response.id] ??
+            (RPCResponse _response) {
+              assert(false,
+                  'We should not be here. Checked above. This code was for type-safety');
+            };
+        handler(response);
+        return;
+      }
+
+      if (subscriptions.containsKey(response.method)) {
+        final handler = subscriptions[response.method] ??
+            (List<Object> params) {
+              assert(false,
+                  'We should not be here. Checked above. This code was for type-safety');
+            };
+        handler(response.params);
+        return;
+      }
+    }, onError: (Object error) {
+      throw UnknownElectrumError('Websocket errored to electrum server', error);
+    }, onDone: () {
+      // Nothing to do?
+    }, cancelOnError: false);
+  }
+
+  Future<dynamic> call(String method, Object params) {
+    final requestId = currentRequestId++;
+    final completer = Completer();
+
+    outstandingRequests[requestId] = (RPCResponse response) {
+      completer.complete(response.result);
+      outstandingRequests.remove(requestId);
+    };
+
+    final payload =
+        jsonEncode(RPCRequest(method, id: requestId, params: params).toJson());
+    rpcSocket.add(payload);
+
+    return completer.future;
+  }
+
+  Future<dynamic> subscribe(
+      String method, Object params, SubscriptionHandler handler) {
+    final requestId = currentRequestId++;
+    final completer = Completer();
+
+    subscriptions[method] = handler;
+
+    outstandingRequests[requestId] = (RPCResponse response) {
+      completer.complete(response.result);
+      outstandingRequests.remove(requestId);
+    };
+
+    final payload =
+        jsonEncode(RPCRequest(method, id: requestId, params: params).toJson());
+    rpcSocket.add(payload);
+
+    return completer.future;
+  }
+
+  void dispose() {
+    rpcSocket.close();
+  }
+}
+
+class ElectrumClient extends JSONRPCWebsocket {
+  Future<Object> blockchainTransactionBroadcast(String transaction) {
+    return call('blockchain.transaction.broadcast', [transaction]);
+  }
+
+  Future<Object> blockchainScripthashListunspent(String scriptHash) {
+    // TODO: Add interface here for this call specifically
+    return call('blockchain.scripthash.listunspent', [scriptHash]);
+  }
+
+  Future<Object> blockchainScripthashSubscribe(
+      String scripthash, SubscriptionHandler resultHandler) {
+    return subscribe(
+        'blockchain.scripthash.subscribe', [scripthash], resultHandler);
+  }
+}

--- a/lib/electrum/rpc.g.dart
+++ b/lib/electrum/rpc.g.dart
@@ -1,0 +1,76 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'rpc.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+RPCRequest _$RPCRequestFromJson(Map<String, dynamic> json) {
+  $checkKeys(json, disallowNullValues: const ['method']);
+  return RPCRequest(
+    json['method'] as String,
+    id: json['id'] as int,
+    params: json['params'],
+  );
+}
+
+Map<String, dynamic> _$RPCRequestToJson(RPCRequest instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('method', instance.method);
+  val['id'] = instance.id;
+  val['params'] = instance.params;
+  return val;
+}
+
+Error _$ErrorFromJson(Map<String, dynamic> json) {
+  $checkKeys(json, disallowNullValues: const ['code', 'message']);
+  return Error(
+    json['code'] as int,
+    json['message'] as String,
+    data: json['data'],
+  );
+}
+
+Map<String, dynamic> _$ErrorToJson(Error instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('code', instance.code);
+  writeNotNull('message', instance.message);
+  val['data'] = instance.data;
+  return val;
+}
+
+RPCResponse _$RPCResponseFromJson(Map<String, dynamic> json) {
+  return RPCResponse(
+    json['result'],
+    id: json['id'] as int,
+    error: json['error'] == null
+        ? null
+        : Error.fromJson(json['error'] as Map<String, dynamic>),
+    method: json['method'] as String,
+    params: json['params'] as List,
+  );
+}
+
+Map<String, dynamic> _$RPCResponseToJson(RPCResponse instance) =>
+    <String, dynamic>{
+      'result': instance.result,
+      'error': instance.error,
+      'id': instance.id,
+      'method': instance.method,
+      'params': instance.params,
+    };

--- a/lib/electrum/rpc_test.dart
+++ b/lib/electrum/rpc_test.dart
@@ -1,0 +1,129 @@
+import 'dart:isolate';
+import 'dart:io';
+import 'dart:convert';
+import 'dart:async';
+import 'package:test/test.dart';
+import 'package:cashew/electrum/rpc.dart';
+
+class FakeElectrumParams {
+  final SendPort sendPort;
+  final List<dynamic> responses;
+  FakeElectrumParams({this.sendPort, this.responses});
+}
+
+void runFakeElectrum(FakeElectrumParams params) async {
+  var httpServer = await HttpServer.bind(InternetAddress.anyIPv4, 0);
+  var url = Uri.parse('ws://${httpServer.address.host}:${httpServer.port}/');
+
+  httpServer.serverHeader = 'Fake Electrum Server';
+
+  httpServer.listen((HttpRequest request) {
+    if (WebSocketTransformer.isUpgradeRequest(request)) {
+      WebSocketTransformer.upgrade(request).then((WebSocket socket) {
+        socket.listen((dynamic msg) {
+          final decodedResponse = jsonDecode(msg as String);
+          final responses = params.responses.where((response) =>
+              response['id'] == decodedResponse['id'] ||
+              response['method'] == decodedResponse['method']);
+          for (final response in responses) {
+            socket.add(jsonEncode(response));
+          }
+        }, onDone: () {
+          print('Client disconnected');
+        });
+      });
+    } else {
+      print('Regular ${request.method} request for: ${request.uri.path}');
+      request.response.statusCode = HttpStatus.forbidden;
+      request.response.reasonPhrase = 'WebSocket connections only';
+      request.response.close();
+    }
+  }, onError: (error) {
+    print('some error');
+    print(error);
+  }, onDone: () {
+    print('done');
+  });
+
+  params.sendPort.send(url);
+}
+
+typedef RPCServerClientCallback = Future<void> Function(Uri url);
+
+Future<Null> Function() withRPCServer(
+    List<Object> responses, RPCServerClientCallback clientTest) {
+  return () async {
+    var receivePort = ReceivePort();
+    var isolate = await Isolate.spawn(
+        runFakeElectrum,
+        FakeElectrumParams(
+            sendPort: receivePort.sendPort, responses: responses));
+    Uri url = await receivePort.first;
+    try {
+      await clientTest(url);
+    } finally {
+      isolate.kill();
+    }
+  };
+}
+
+void main() {
+  test(
+      'json rpc happy-path works',
+      withRPCServer([
+        {
+          'id': 0,
+          'result': ['poop']
+        },
+        {'id': 1, 'result': []}
+      ], (Uri url) async {
+        final client = JSONRPCWebsocket();
+        await client.connect(url);
+        final result = await client.call('poop', []);
+        expect(result, ['poop']);
+        client.dispose();
+      }));
+
+  test(
+      'electrum client basic method works',
+      withRPCServer([
+        {
+          'method': 'blockchain.scripthash.subscribe',
+          'params': ['foo', 'bar']
+        },
+        {
+          'method': 'blockchain.scripthash.subscribe',
+          'params': ['bob', 'bar']
+        },
+        {'id': 0, 'result': 'some weird electrum hash'},
+      ], (Uri url) async {
+        final client = ElectrumClient();
+        await client.connect(url);
+        var currentCompleter = 0;
+        var testTable = [
+          {
+            'completer': Completer(),
+            'expectedResult': ['foo', 'bar'],
+          },
+          {
+            'completer': Completer(),
+            'expectedResult': ['bob', 'bar']
+          }
+        ];
+        final result =
+            await client.blockchainScripthashSubscribe('Test', (params) {
+          final completer =
+              testTable[currentCompleter++]['completer'] as Completer;
+          completer.complete(params);
+        });
+        expect(result, 'some weird electrum hash');
+
+        for (final tableEntry in testTable) {
+          final completer = tableEntry['completer'] as Completer;
+          final params = await completer.future;
+          final expectedResult = tableEntry['expectedResult'];
+          expect(params, expectedResult);
+        }
+        client.dispose();
+      }));
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,12 @@
+// import 'package:cashew/electrum.dart';
 import 'package:cashew/tabs/balance.dart';
 import 'package:cashew/tabs/receive.dart';
 import 'package:cashew/tabs/send.dart';
 import 'package:cashew/wallet.dart';
 import 'package:flutter/material.dart';
+import 'package:cashew/electrum/rpc.dart';
 
-void main() {
-  runApp(CashewApp());
-}
+import 'constants.dart';
 
 class CashewApp extends StatelessWidget {
   @override
@@ -33,6 +33,13 @@ class MainPage extends StatefulWidget {
 
 class _MainPageState extends State<MainPage> {
   Wallet wallet = Wallet('todo');
+  ElectrumClient client = ElectrumClient();
+
+  @override
+  void initState() {
+    super.initState();
+    client.connect(Uri.parse(electrumUrl));
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -50,6 +50,41 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.0"
+  build_config:
+    dependency: transitive
+    description:
+      name: build_config
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.2"
+  build_daemon:
+    dependency: transitive
+    description:
+      name: build_daemon
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.4"
+  build_resolvers:
+    dependency: transitive
+    description:
+      name: build_resolvers
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.4.2"
+  build_runner:
+    dependency: "direct dev"
+    description:
+      name: build_runner
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.10.4"
+  build_runner_core:
+    dependency: transitive
+    description:
+      name: build_runner_core
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.3"
   built_collection:
     dependency: transitive
     description:
@@ -78,6 +113,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0-nullsafety.1"
+  checked_yaml:
+    dependency: transitive
+    description:
+      name: checked_yaml
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
   cli_util:
     dependency: transitive
     description:
@@ -186,6 +228,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
+  graphs:
+    dependency: transitive
+    description:
+      name: graphs
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
   hex:
     dependency: "direct main"
     description:
@@ -242,6 +291,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.0"
+  json_serializable:
+    dependency: "direct dev"
+    description:
+      name: json_serializable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.5.0"
   logging:
     dependency: transitive
     description:
@@ -340,6 +396,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.4"
+  pubspec_parse:
+    dependency: transitive
+    description:
+      name: pubspec_parse
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.5"
   qr:
     dependency: transitive
     description:
@@ -457,6 +520,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0-nullsafety.1"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.0"
   string_scanner:
     dependency: transitive
     description:
@@ -492,6 +562,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.12-nullsafety.5"
+  timing:
+    dependency: transitive
+    description:
+      name: timing
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.1+2"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,8 @@ dev_dependencies:
   pedantic: ^1.9.2
   test: ^1.0.0
   mockito: ^4.0.0
+  build_runner: ^1.0.0
+  json_serializable: ^3.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
This commit adds the basic components needed for an electrum client
in our flutter wallet. It only implements the websocket based transit
for the JSON-RPC calls. However, it should be relatively easy to swap
the transit out if needed.