### PR TITLE
Add loading page

### DIFF
--- a/lib/loading_page.dart
+++ b/lib/loading_page.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+class LoadingPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final text = Text(
+      'Loading wallet...',
+      style: TextStyle(fontSize: 24),
+    );
+    final indicator = SizedBox(
+        height: 48,
+        width: 48,
+        child: CircularProgressIndicator(
+          strokeWidth: 6,
+        ));
+    return Scaffold(
+      body: Center(
+          child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Padding(
+            child: text,
+            padding: EdgeInsets.all(24),
+          ),
+          Padding(child: indicator, padding: EdgeInsets.all(24))
+        ],
+      )),
+    );
+  }
+}


### PR DESCRIPTION
Bitcoin wallet may take some while to initialize either: loading history and keys from disk if the app has been used before or hashing to generate the bitcoin wallet root key.

To accommodate this we add a loading page.