### PR TITLE
Ensure Send Info screen isn't constantly redrawn

### DIFF
--- a/lib/tabs/send/send.dart
+++ b/lib/tabs/send/send.dart
@@ -8,14 +8,29 @@ import 'package:qr_code_scanner/qr_code_scanner.dart';
 
 import './send_info.dart';
 
-class SendTab extends StatelessWidget {
+class SendTab extends StatefulWidget {
   SendTab({Key key}) : super(key: key);
 
+  @override
+  _SendTabState createState() => _SendTabState();
+}
+
+class _SendTabState extends State<SendTab> {
   final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');
+
+  ValueNotifier<bool> showSendInfoScreen;
+
+  @override
+  void initState() {
+    // TODO: implement initState
+    showSendInfoScreen = ValueNotifier<bool>(false);
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {
-    final viewModel = Provider.of<CashewModel>(context);
+    // WE don't want to be redrawing
+    final viewModel = Provider.of<CashewModel>(context, listen: false);
 
     final overlay = QrScannerOverlayShape(
       borderColor: Colors.red,
@@ -35,7 +50,7 @@ class SendTab extends StatelessWidget {
             // not desirable.
             Address(scanData);
             if (scanData != viewModel.sendToAddress) {
-              viewModel.showSendInfoScreen = true;
+              showSendInfoScreen.value = true;
             }
           } catch (e) {
             print('error parsing address');
@@ -46,19 +61,21 @@ class SendTab extends StatelessWidget {
       overlay: overlay,
     );
 
-    return (Column(
-        children: viewModel.showSendInfoScreen
-            ? [SendInfo()]
-            : [
-                Expanded(child: qrWidget),
-                Row(children: [
-                  Expanded(
-                      child: ElevatedButton(
-                    autofocus: true,
-                    onPressed: () => viewModel.showSendInfoScreen = true,
-                    child: Text('Enter Address'),
-                  ))
-                ]),
-              ]));
+    return ValueListenableBuilder(
+        valueListenable: showSendInfoScreen,
+        builder: (context, shouldShowSendInfoScreen, child) => Column(
+            children: shouldShowSendInfoScreen
+                ? [SendInfo(visible: showSendInfoScreen)]
+                : [
+                    Expanded(child: qrWidget),
+                    Row(children: [
+                      Expanded(
+                          child: ElevatedButton(
+                        autofocus: true,
+                        onPressed: () => showSendInfoScreen.value = true,
+                        child: Text('Enter Address'),
+                      ))
+                    ]),
+                  ]));
   }
 }

--- a/lib/tabs/send/send_info.dart
+++ b/lib/tabs/send/send_info.dart
@@ -19,7 +19,9 @@ Future showReceipt(BuildContext context, Transaction transaction) {
 }
 
 class SendInfo extends StatelessWidget {
-  SendInfo();
+  final ValueNotifier<bool> visible;
+
+  SendInfo({this.visible});
 
   void sendButtonClicked(
       BuildContext context, Wallet wallet, String address, int amount) {
@@ -63,6 +65,17 @@ class SendInfo extends StatelessWidget {
             children: [
               Expanded(
                   child: TextField(
+                autocorrect: false,
+                enableInteractiveSelection: true,
+                autofocus: true,
+                toolbarOptions: ToolbarOptions(
+                  paste: true,
+                  cut: true,
+                  copy: true,
+                  selectAll: true,
+                ),
+                readOnly: false,
+                focusNode: FocusNode(),
                 controller: addressController,
                 keyboardType: TextInputType.text,
                 decoration: InputDecoration(
@@ -77,6 +90,16 @@ class SendInfo extends StatelessWidget {
                 padding: stdPadding,
                 child: TextField(
                   autocorrect: false,
+                  enableInteractiveSelection: true,
+                  autofocus: false,
+                  toolbarOptions: ToolbarOptions(
+                    paste: true,
+                    cut: true,
+                    copy: true,
+                    selectAll: true,
+                  ),
+                  readOnly: false,
+                  focusNode: FocusNode(),
                   controller: amountController,
                   keyboardType: TextInputType.number,
                   decoration: InputDecoration(
@@ -95,7 +118,7 @@ class SendInfo extends StatelessWidget {
                       // specifically for this component
                       // Rather than wiring directly to the global viewmodel
                       onPressed: () {
-                        viewModel.showSendInfoScreen = false;
+                        visible.value = false;
                         viewModel.sendAmount = null;
                       },
                       child: Text('Cancel'),
@@ -110,7 +133,7 @@ class SendInfo extends StatelessWidget {
                       onPressed: () {
                         sendButtonClicked(context, viewModel.activeWallet,
                             viewModel.sendToAddress, viewModel.sendAmount);
-                        viewModel.showSendInfoScreen = false;
+                        visible.value = false;
                         viewModel.sendAmount = null;
                       },
                       child: Text('Send'),

--- a/lib/viewmodel.dart
+++ b/lib/viewmodel.dart
@@ -8,7 +8,6 @@ class CashewModel with ChangeNotifier {
 
   Wallet _activeWallet;
   bool _initialized = false;
-  bool _showSendInfoScreen = false;
 
   CashewModel(sendToAddress, activeWallet) {
     this.sendToAddress = _sendToAddress;
@@ -35,13 +34,6 @@ class CashewModel with ChangeNotifier {
 
   set activeWallet(Wallet newValue) {
     _activeWallet = newValue;
-    notifyListeners();
-  }
-
-  bool get showSendInfoScreen => _showSendInfoScreen;
-
-  set showSendInfoScreen(bool newValue) {
-    _showSendInfoScreen = newValue;
     notifyListeners();
   }
 


### PR DESCRIPTION
Because the flag to show the SendInfo screen was attached to the global
ViewModel, the SendInfo screen was redrawing whenever any of the other
viewmodel fields were being updated. (Which that screen does a lot of).
This was causing it to redraw and thus reset some internal state such as
where cursors were positioned in text fields.

This moves the state to a ValueNotifier within the specific Send screen
tab widget.