### PR TITLE
Ensure that toDER correctly returns the signature encoded bytes

### DIFF
--- a/lib/bitcoincash/src/signature.dart
+++ b/lib/bitcoincash/src/signature.dart
@@ -228,7 +228,7 @@ class BCHSignature {
     seq.add(ASN1Integer(_r));
     seq.add(ASN1Integer(_s));
 
-    return seq.encodedBytes;
+    return seq.encode();
   }
 
   /// [ported from moneybutton/bsv]


### PR DESCRIPTION
Presumably, the API for the crypto lib changed during the migration
from dartsv to our repository. The encodedBytes prop is actually null
until encode() is called. Encode() also returns the bytes.