### PR TITLE
Fork AS1 libraries locally w/ serialization fix for integers

### DIFF
--- a/lib/bitcoincash/src/encoding/asn1.dart
+++ b/lib/bitcoincash/src/encoding/asn1.dart
@@ -1,0 +1,24 @@
+library asn1;
+
+export 'asn1/asn1_encoding_rule.dart';
+export 'asn1/asn1_object.dart';
+export 'asn1/asn1_parser.dart';
+export 'asn1/asn1_tags.dart';
+export 'asn1/asn1_utils.dart';
+export 'asn1/primitives/asn1_bit_string.dart';
+export 'asn1/primitives/asn1_boolean.dart';
+export 'asn1/primitives/asn1_enumerated.dart';
+export 'asn1/primitives/asn1_generalized_time.dart';
+export 'asn1/primitives/asn1_ia5_string.dart';
+export 'asn1/primitives/asn1_integer.dart';
+export 'asn1/primitives/asn1_null.dart';
+export 'asn1/primitives/asn1_object_identifier.dart';
+export 'asn1/primitives/asn1_octet_string.dart';
+export 'asn1/primitives/asn1_printable_string.dart';
+export 'asn1/primitives/asn1_sequence.dart';
+export 'asn1/primitives/asn1_set.dart';
+export 'asn1/primitives/asn1_teletext_string.dart';
+export 'asn1/primitives/asn1_utc_time.dart';
+export 'asn1/primitives/asn1_utf8_string.dart';
+export 'asn1/unsupported_asn1_encoding_rule_exception.dart';
+export 'asn1/unsupported_asn1_tag_exception.dart';

--- a/lib/bitcoincash/src/encoding/asn1/asn1_encoding_rule.dart
+++ b/lib/bitcoincash/src/encoding/asn1/asn1_encoding_rule.dart
@@ -1,0 +1,16 @@
+enum ASN1EncodingRule {
+  /// Normal DER encoding rules
+  ENCODING_DER,
+
+  /// BER encoding where the length is described in a long form
+  ENCODING_BER_LONG_LENGTH_FORM,
+
+  /// BER Constructed encoding with definite length
+  ENCODING_BER_CONSTRUCTED,
+
+  /// BER encoding with padded bits to make the length of the value bytes a multiple of eight. Only used for ASN1BitString
+  ENCODING_BER_PADDED,
+
+  /// BER Constructed encoding with indefinite length
+  ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH
+}

--- a/lib/bitcoincash/src/encoding/asn1/asn1_object.dart
+++ b/lib/bitcoincash/src/encoding/asn1/asn1_object.dart
@@ -1,0 +1,139 @@
+import 'dart:typed_data';
+
+import './asn1_parser.dart';
+import './asn1_encoding_rule.dart';
+import './asn1_utils.dart';
+
+///
+/// Base model for all ASN1Objects
+///
+class ASN1Object {
+  ///
+  /// The BER tag representing this object.
+  ///
+  /// For a list of all supported BER tags take a look in the **Asn1Tags** class.
+  ///
+  int tag;
+
+  ///
+  /// The encoded bytes.
+  ///
+  Uint8List encodedBytes;
+
+  ///
+  /// The value bytes.
+  ///
+  Uint8List valueBytes;
+
+  ///
+  /// The index where the value bytes start. This is the position after the tag + length bytes.
+  ///
+  /// The default value for this field is 2. If the length byte is larger than **127**, the value of this field will increase depending on the length bytes.
+  ///
+  int valueStartPosition = 2;
+
+  ///
+  /// Length of the encoded value bytes.
+  ///
+  int valueByteLength;
+
+  ///
+  /// Describes if this ASN1 Object is constructed.
+  ///
+  /// The object is marked as constructed if bit 6 of the [tag] field has value **1**
+  ///
+  bool isConstructed;
+
+  int dumpIndent = 2;
+
+  ASN1Object({this.tag}) {
+    if (tag != null) {
+      isConstructed = ASN1Utils.isConstructed(tag);
+    }
+  }
+
+  ///
+  /// Creates a new ASN1Object from the given [encodedBytes].
+  ///
+  /// The first byte will be used as the [tag].The field [valueStartPosition] and [valueByteLength] will be calculated on the given [encodedBytes].
+  ///
+  ASN1Object.fromBytes(this.encodedBytes) {
+    tag = encodedBytes[0];
+    isConstructed = ASN1Utils.isConstructed(tag);
+    valueByteLength = ASN1Utils.decodeLength(encodedBytes);
+    valueStartPosition = ASN1Utils.calculateValueStartPosition(encodedBytes);
+    if (valueByteLength == -1) {
+      // Indefinite length, check the last to bytes
+      if (ASN1Utils.hasIndefiniteLengthEnding(encodedBytes)) {
+        valueByteLength = encodedBytes.length - 4;
+      }
+    }
+    valueBytes = Uint8List.view(encodedBytes.buffer,
+        valueStartPosition + encodedBytes.offsetInBytes, valueByteLength);
+  }
+
+  ///
+  /// Encode the object to their byte representation.
+  ///
+  /// [encodingRule] defines if the [valueByteLength] should be encoded as indefinite length (0x80) or fixed length with short/long form.
+  /// The default is [ASN1EncodingRule.ENCODING_DER] which will automatically decode in definite length with short form.
+  ///
+  /// **Important note**: Subclasses need to override this method and may call this method. If this method is called by a subclass, the subclass has to set the [valueBytes] before calling super.encode().
+  ///
+  Uint8List encode(
+      {ASN1EncodingRule encodingRule = ASN1EncodingRule.ENCODING_DER}) {
+    if (encodedBytes == null) {
+      // Encode the length
+      Uint8List lengthAsBytes;
+      valueByteLength ??= valueBytes.length;
+      // Check if we have indefinite length or fixed length (short or longform)
+      if (encodingRule ==
+          ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH) {
+        // Set length to 0x80
+        lengthAsBytes = Uint8List.fromList([0x80]);
+        // Add 2 to the valueByteLength to handle the 0x00, 0x00 at the end
+        //valueByteLength = valueByteLength + 2;
+      } else {
+        lengthAsBytes = ASN1Utils.encodeLength(valueByteLength,
+            longform:
+                encodingRule == ASN1EncodingRule.ENCODING_BER_LONG_LENGTH_FORM);
+      }
+      // Create the Uint8List with the calculated length
+      encodedBytes = Uint8List(1 + lengthAsBytes.length + valueByteLength);
+      // Set the tag
+      encodedBytes[0] = tag;
+      // Set the length bytes
+      encodedBytes.setRange(1, 1 + lengthAsBytes.length, lengthAsBytes, 0);
+      // Set the value bytes
+      encodedBytes.setRange(
+          1 + lengthAsBytes.length, encodedBytes.length, valueBytes, 0);
+    }
+    return encodedBytes;
+  }
+
+  ///
+  /// The total length of this object, including its value bytes, the encoded tag and length bytes.
+  ///
+  int get totalEncodedByteLength => valueStartPosition + valueByteLength;
+
+  ///
+  /// Creates a readable dump from the current ASN1Object.
+  ///
+  /// **Important note**: Subclasses need to override this method. If the ASN1Object is constructed and has child elements, dump() has to be called for each child element.
+  ///
+  String dump({int spaces = 0}) {
+    var sb = StringBuffer();
+    for (var i = 0; i < spaces; i++) {
+      sb.write(' ');
+    }
+    if (tag == 0xA0 || tag == 0xA3) {
+      sb.write('[$tag]');
+      var parser = ASN1Parser(valueBytes);
+      var next = parser.nextObject();
+      var dump = next.dump(spaces: spaces + dumpIndent);
+      sb.write('\n$dump');
+    }
+    sb.write('UNKNOWN');
+    return sb.toString();
+  }
+}

--- a/lib/bitcoincash/src/encoding/asn1/asn1_parser.dart
+++ b/lib/bitcoincash/src/encoding/asn1/asn1_parser.dart
@@ -1,0 +1,152 @@
+import 'dart:typed_data';
+
+import './asn1_object.dart';
+import './asn1_tags.dart';
+import './asn1_utils.dart';
+import './primitives/asn1_bit_string.dart';
+import './primitives/asn1_boolean.dart';
+import './primitives/asn1_generalized_time.dart';
+import './primitives/asn1_ia5_string.dart';
+import './primitives/asn1_integer.dart';
+import './primitives/asn1_null.dart';
+import './primitives/asn1_object_identifier.dart';
+import './primitives/asn1_octet_string.dart';
+import './primitives/asn1_printable_string.dart';
+import './primitives/asn1_sequence.dart';
+import './primitives/asn1_set.dart';
+import './primitives/asn1_teletext_string.dart';
+import './primitives/asn1_utc_time.dart';
+import './primitives/asn1_utf8_string.dart';
+import './unsupported_asn1_tag_exception.dart';
+
+///
+/// The ASN1Parser to parse bytes into ASN1 Objects
+///
+class ASN1Parser {
+  ///
+  /// The bytes to parse
+  ///
+  final Uint8List bytes;
+
+  ///
+  /// The current position in the byte array.
+  ///
+  /// The inital value is 0.
+  ///
+  int _position = 0;
+
+  ASN1Parser(this.bytes);
+
+  ///
+  /// Returns true if there is still an object to parse. Otherwise false.
+  ///
+  bool hasNext() {
+    return _position < bytes.length;
+  }
+
+  ///
+  /// Parses the next object in the [bytes].
+  ///
+  ASN1Object nextObject() {
+    // Get the current tag in the list bytes
+    var tag = bytes[_position];
+
+    // Get the length of the value bytes for the current object
+    var length = ASN1Utils.decodeLength(bytes.sublist(_position));
+
+    var valueStartPosition =
+        ASN1Utils.calculateValueStartPosition(bytes.sublist(_position));
+    if (_position < length + valueStartPosition) {
+      length = length + valueStartPosition;
+    } else {
+      length = bytes.length - _position;
+    }
+
+    // Create new view from the bytes
+    var offset = _position + bytes.offsetInBytes;
+    var subBytes = Uint8List.view(bytes.buffer, offset, length);
+
+    // Parse the view and the tag to an ASN1Object
+    var isConstructed = ASN1Utils.isConstructed(tag);
+    var isPrimitive = (0xC0 & tag) == 0;
+    //var isApplication = (0x40 & tag) != 0;
+
+    ASN1Object obj;
+    if (isConstructed) {
+      obj = _createConstructed(tag, subBytes);
+    } else if (isPrimitive) {
+      obj = _createPrimitive(tag, subBytes);
+    } else {
+      // create a vanilla object
+      obj = ASN1Object.fromBytes(subBytes);
+    }
+
+    // Update the position
+    _position = _position + obj.totalEncodedByteLength;
+    return obj;
+  }
+
+  ///
+  /// Creates a constructed ASN1Object depending on the given [tag] and [bytes]
+  ///
+  ASN1Object _createConstructed(int tag, Uint8List bytes) {
+    switch (tag) {
+      case ASN1Tags.SEQUENCE: // sequence
+        return ASN1Sequence.fromBytes(bytes);
+      case ASN1Tags.SET:
+        return ASN1Set.fromBytes(bytes);
+      case ASN1Tags.IA5_STRING_CONSTRUCTED:
+        return ASN1IA5String.fromBytes(bytes);
+      case ASN1Tags.BIT_STRING_CONSTRUCTED:
+        return ASN1BitString.fromBytes(bytes);
+      case ASN1Tags.OCTET_STRING_CONSTRUCTED:
+        return ASN1OctetString.fromBytes(bytes);
+      case ASN1Tags.PRINTABLE_STRING_CONSTRUCTED:
+        return ASN1PrintableString.fromBytes(bytes);
+      case ASN1Tags.T61_STRING_CONSTRUCTED:
+        return ASN1TeletextString.fromBytes(bytes);
+      case 0xA0:
+      case 0xA1:
+      case 0xA2:
+      case 0xA3:
+        return ASN1Object.fromBytes(bytes);
+      default:
+        throw UnsupportedASN1TagException(tag);
+    }
+  }
+
+  ///
+  /// Creates a primitive ASN1Object depending on the given [tag] and [bytes]
+  ///
+  ASN1Object _createPrimitive(int tag, Uint8List bytes) {
+    switch (tag) {
+      case ASN1Tags.OCTET_STRING:
+        return ASN1OctetString.fromBytes(bytes);
+      case ASN1Tags.UTF8_STRING:
+        return ASN1UTF8String.fromBytes(bytes);
+      case ASN1Tags.IA5_STRING:
+        return ASN1IA5String.fromBytes(bytes);
+      case ASN1Tags.INTEGER:
+      case ASN1Tags.ENUMERATED:
+        return ASN1Integer.fromBytes(bytes);
+      case ASN1Tags.BOOLEAN:
+        return ASN1Boolean.fromBytes(bytes);
+      case ASN1Tags.OBJECT_IDENTIFIER:
+        return ASN1ObjectIdentifier.fromBytes(bytes);
+      case ASN1Tags.BIT_STRING:
+        return ASN1BitString.fromBytes(bytes);
+      case ASN1Tags.NULL:
+        return ASN1Null.fromBytes(bytes);
+      case ASN1Tags.PRINTABLE_STRING:
+        return ASN1PrintableString.fromBytes(bytes);
+      case ASN1Tags.UTC_TIME:
+        return ASN1UtcTime.fromBytes(bytes);
+      case ASN1Tags.T61_STRING:
+        return ASN1TeletextString.fromBytes(bytes);
+      case ASN1Tags.GENERALIZED_TIME:
+        return ASN1GeneralizedTime.fromBytes(bytes);
+      default:
+        throw UnsupportedASN1TagException(tag);
+    }
+  }
+}

--- a/lib/bitcoincash/src/encoding/asn1/asn1_tags.dart
+++ b/lib/bitcoincash/src/encoding/asn1/asn1_tags.dart
@@ -1,0 +1,133 @@
+///
+/// Class holding all ASN1 BER tags, supported by this package
+///
+class ASN1Tags {
+  static const List<int> TAGS = [
+    BOOLEAN,
+    INTEGER,
+    BIT_STRING,
+    BIT_STRING_CONSTRUCTED,
+    OCTET_STRING,
+    OCTET_STRING_CONSTRUCTED,
+    NULL,
+    OBJECT_IDENTIFIER,
+    EXTERNAL,
+    ENUMERATED,
+    UTF8_STRING,
+    UTF8_STRING_CONSTRUCTED,
+    SEQUENCE,
+    SEQUENCE_OF,
+    SET,
+    SET_OF,
+    T61_STRING,
+    T61_STRING_CONSTRUCTED,
+    PRINTABLE_STRING,
+    PRINTABLE_STRING_CONSTRUCTED,
+    IA5_STRING,
+    IA5_STRING_CONSTRUCTED,
+    UTC_TIME,
+    GENERALIZED_TIME
+  ];
+
+  /// Decimal 1
+  static const int BOOLEAN = 0x01;
+
+  /// Decimal 2
+  static const int INTEGER = 0x02;
+
+  /// Decimal 3
+  static const int BIT_STRING = 0x03;
+
+  /// Decimal 35
+  static const int BIT_STRING_CONSTRUCTED = 0x23;
+
+  /// Decimal 4
+  static const int OCTET_STRING = 0x04;
+
+  /// Decimal 36
+  static const int OCTET_STRING_CONSTRUCTED = 0x24;
+
+  /// Decimal 5
+  static const int NULL = 0x05;
+
+  /// Decimal 6
+  static const int OBJECT_IDENTIFIER = 0x06;
+
+  /// Decimal 8
+  static const int EXTERNAL = 0x08;
+
+  /// Decimal 10
+  static const int ENUMERATED = 0x0a;
+
+  /// Decimal 12
+  static const int UTF8_STRING = 0x0c;
+
+  /// Decimal 44
+  static const int UTF8_STRING_CONSTRUCTED = 0x2C;
+
+  /// Decimal 48
+  static const int SEQUENCE = 0x30;
+
+  /// Decimal 48
+  static const int SEQUENCE_OF = 0x30;
+
+  /// Decimal 49
+  static const int SET = 0x31;
+
+  /// Decimal 49
+  static const int SET_OF = 0x31;
+
+  /// Decimal 18
+  static const int NUMERIC_STRING = 0x12;
+
+  /// Decimal 19
+  static const int PRINTABLE_STRING = 0x13;
+
+  /// Decimal 51
+  static const int PRINTABLE_STRING_CONSTRUCTED = 0x33;
+
+  /// Decimal 20
+  static const int T61_STRING = 0x14;
+
+  /// Decimal 52
+  static const int T61_STRING_CONSTRUCTED = 0x34;
+
+  /// Decimal 21
+  static const int VIDEOTEX_STRING = 0x15;
+
+  /// Decimal 22
+  static const int IA5_STRING = 0x16;
+
+  /// Decimal 54
+  static const int IA5_STRING_CONSTRUCTED = 0x36;
+
+  /// Decimal 23
+  static const int UTC_TIME = 0x17;
+
+  /// Decimal 24
+  static const int GENERALIZED_TIME = 0x18;
+
+  /// Decimal 25
+  static const int GRAPHIC_STRING = 0x19;
+
+  /// Decimal 26
+  static const int VISIBLE_STRING = 0x1a;
+
+  /// Decimal 27
+  static const int GENERAL_STRING = 0x1b;
+
+  /// Decimal 28
+  static const int UNIVERSAL_STRING = 0x1c;
+
+  /// Decimal 30
+  static const int BMP_STRING = 0x1e;
+
+  /// Decimal 32
+  static const int CONSTRUCTED = 0x20;
+
+  /// Decimal 64
+  static const int APPLICATION = 0x40;
+
+  /// Decimal 128
+  static const int TAGGED = 0x80;
+}

--- a/lib/bitcoincash/src/encoding/asn1/asn1_utils.dart
+++ b/lib/bitcoincash/src/encoding/asn1/asn1_utils.dart
@@ -1,0 +1,147 @@
+import 'dart:typed_data';
+
+import './asn1_tags.dart';
+
+///
+/// Utils class holding different methods to ease the handling of ANS1Objects and their byte representation.
+///
+class ASN1Utils {
+  /// Decode a BigInt from bytes in big-endian encoding.
+  static BigInt decodeBigInt(List<int> bytes) {
+    var result = BigInt.from(0);
+    for (var i = 0; i < bytes.length; i++) {
+      result += BigInt.from(bytes[bytes.length - i - 1]) << (8 * i);
+    }
+    return result;
+  }
+
+  static final _byteMask = BigInt.from(0xff);
+  static final negativeFlag = BigInt.from(0x80);
+
+  /// Encode a BigInt into bytes using big-endian encoding.
+  static Uint8List encodeBigInt(BigInt number) {
+    // Not handling negative numbers. Decide how you want to do that.
+    var rawSize = (number.bitLength + 7) >> 3;
+    // If the first byte has 0x80 set, we need an extra byte
+    final needsPaddingByte = number > BigInt.from(0) &&
+            ((number >> (rawSize - 1) * 8) & negativeFlag) == negativeFlag
+        ? 1
+        : 0;
+    final size = rawSize + needsPaddingByte;
+    var result = Uint8List(size);
+    for (var i = 0; i < rawSize; i++) {
+      result[size - i - 1] = (number & _byteMask).toInt();
+      number = number >> 8;
+    }
+    return result;
+  }
+
+  ///
+  /// Calculates the start position of the value bytes for the given [encodedBytes].
+  ///
+  /// It will return 2 if the **length byte** is less than 127 or the length calculate on the **length byte** value.
+  /// This will throw a [RangeError] if the given [encodedBytes] has length < 2.
+  ///
+  static int calculateValueStartPosition(Uint8List encodedBytes) {
+    var length = encodedBytes[1];
+    if (length < 0x7F) {
+      return 2;
+    } else {
+      return 2 + (length & 0x7F);
+    }
+  }
+
+  ///
+  /// Calculates the length of the **value bytes** for the given [encodedBytes].
+  ///
+  /// Will return **-1** if the length byte equals **0x80**. Throws an [ArgumentError] if the length could not be calculated for the given [encodedBytes].
+  ///
+  static int decodeLength(Uint8List encodedBytes) {
+    var valueStartPosition = 2;
+    var length = encodedBytes[1];
+    if (length < 0x7F) {
+      return length;
+    }
+    if (length == 0x80) {
+      return -1;
+    }
+    if (length > 127) {
+      var length = encodedBytes[1] & 0x7F;
+
+      var numLengthBytes = length;
+
+      length = 0;
+      for (var i = 0; i < numLengthBytes; i++) {
+        length <<= 8;
+        length |= (encodedBytes[valueStartPosition++] & 0xFF);
+      }
+      return length;
+    }
+    throw ArgumentError('Could not calculate the length from the given bytes.');
+  }
+
+  ///
+  /// Encode the given [length] to byte representation.
+  ///
+  static Uint8List encodeLength(int length, {bool longform = false}) {
+    Uint8List e;
+    if (length <= 127 && longform == false) {
+      e = Uint8List(1);
+      e[0] = length;
+    } else {
+      var x = Uint32List(1);
+      x[0] = length;
+      var y = Uint8List.view(x.buffer);
+      // Skip null bytes
+      var num = 3;
+      while (y[num] == 0) {
+        --num;
+      }
+      e = Uint8List(num + 2);
+      e[0] = 0x80 + num + 1;
+      for (var i = 1; i < e.length; ++i) {
+        e[i] = y[num--];
+      }
+    }
+    return e;
+  }
+
+  ///
+  /// Checks if the given int [i] is constructed according to <https://www.bouncycastle.org/asn1_layman_93.txt> section 3.2.
+  ///
+  /// The Identifier octets (represented by the given [i]) is marked as constructed if bit 6 has the value **1**.
+  ///
+  /// Example with the IA5 String tag:
+  ///
+  /// 0x36 = 0 0 1 1 0 1 1 0
+  ///
+  /// 0x16 = 0 0 0 1 0 1 1 0
+  /// ```
+  /// ASN1Utils.isConstructed(0x36);  // true
+  /// ASN1Utils.isConstructed(0x16);  // false
+  /// ```
+  ///
+  ///
+  static bool isConstructed(int i) {
+    // Shift bits
+    var newNum = i >> (6 - 1);
+    // Check if bit is set to 1
+    return (newNum & 1) == 1;
+  }
+
+  static bool isASN1Tag(int i) {
+    return ASN1Tags.TAGS.contains(i);
+  }
+
+  ///
+  /// Checks if the given [bytes] ends with 0x00, 0x00
+  ///
+  static bool hasIndefiniteLengthEnding(Uint8List bytes) {
+    var last = bytes.elementAt(bytes.length - 1);
+    var lastMinus1 = bytes.elementAt(bytes.length - 2);
+    if (last == 0 && lastMinus1 == 0) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/lib/bitcoincash/src/encoding/asn1/object_identifiers.dart
+++ b/lib/bitcoincash/src/encoding/asn1/object_identifiers.dart
@@ -1,0 +1,288 @@
+///
+/// Class holding a list of object identifiers
+///
+class ObjectIdentifiers {
+  ///
+  /// A list of object identifiers, holding the identifier and a readable name.
+  ///
+  static const oi = [
+    {
+      'identifierString': '2.5.4.3',
+      'readableName': 'commonName',
+      'identifier': [2, 5, 4, 3]
+    },
+    {
+      'identifierString': '2.5.4.6',
+      'readableName': 'countryName',
+      'identifier': [2, 5, 4, 6]
+    },
+    {
+      'identifierString': '2.5.4.10',
+      'readableName': 'organizationName',
+      'identifier': [2, 5, 4, 10]
+    },
+    {
+      'identifierString': '2.5.4.11',
+      'readableName': 'organizationalUnitName',
+      'identifier': [2, 5, 4, 11]
+    },
+    {
+      'identifierString': '1.3.6.1.4.1.311.60.2.1.3',
+      'readableName': 'jurisdictionOfIncorporationC',
+      'identifier': [1, 3, 6, 1, 4, 1, 311, 60, 2, 1, 3]
+    },
+    {
+      'identifierString': '1.3.6.1.4.1.311.60.2.1.2',
+      'readableName': 'jurisdictionOfIncorporationSP',
+      'identifier': [1, 3, 6, 1, 4, 1, 311, 60, 2, 1, 2]
+    },
+    {
+      'identifierString': '1.3.6.1.4.1.311.60.2.1.1',
+      'readableName': 'jurisdictionOfIncorporationL',
+      'identifier': [1, 3, 6, 1, 4, 1, 311, 60, 2, 1, 1]
+    },
+    {
+      'identifierString': '2.5.4.15',
+      'readableName': 'businessCategory',
+      'identifier': [2, 5, 4, 15]
+    },
+    {
+      'identifierString': '2.5.4.5',
+      'readableName': 'serialNumber',
+      'identifier': [2, 5, 4, 5]
+    },
+    {
+      'identifierString': '2.5.4.8',
+      'readableName': 'stateOrProvinceName',
+      'identifier': [2, 5, 4, 8]
+    },
+    {
+      'identifierString': '2.5.4.7',
+      'readableName': 'localityName',
+      'identifier': [2, 5, 4, 7]
+    },
+    {
+      'identifierString': '1.2.840.113549.1.1.1',
+      'readableName': 'rsaEncryption',
+      'identifier': [1, 2, 840, 113549, 1, 1, 1]
+    },
+    {
+      'identifierString': '2.5.29.17',
+      'readableName': 'subjectAltName',
+      'identifier': [2, 5, 29, 17]
+    },
+    {
+      'identifierString': '2.5.29.32',
+      'readableName': 'certificatePolicies',
+      'identifier': [2, 5, 29, 32]
+    },
+    {
+      'identifierString': '2.16.840.1.113733.1.7.23.6',
+      'readableName': 'VeriSign EV policy',
+      'identifier': [2, 16, 840, 1, 113733, 1, 7, 23, 6]
+    },
+    {
+      'identifierString': '1.3.6.1.5.5.7.2.1',
+      'readableName': 'cps',
+      'identifier': [1, 3, 6, 1, 5, 5, 7, 2, 1]
+    },
+    {
+      'identifierString': '1.3.6.1.5.5.7.2.2',
+      'readableName': 'unotice',
+      'identifier': [1, 3, 6, 1, 5, 5, 7, 2, 2]
+    },
+    {
+      'identifierString': '2.5.29.31',
+      'readableName': 'cRLDistributionPoints',
+      'identifier': [2, 5, 29, 31]
+    },
+    {
+      'identifierString': '2.5.29.37',
+      'readableName': 'extKeyUsage',
+      'identifier': [2, 5, 29, 37]
+    },
+    {
+      'identifierString': '2.5.29.35',
+      'readableName': 'authorityKeyIdentifier',
+      'identifier': [2, 5, 29, 35]
+    },
+    {
+      'identifierString': '1.3.6.1.5.5.7.3.1',
+      'readableName': 'serverAuth',
+      'identifier': [1, 3, 6, 1, 5, 5, 7, 3, 1]
+    },
+    {
+      'identifierString': '1.3.6.1.5.5.7.3.2',
+      'readableName': 'clientAuth',
+      'identifier': [1, 3, 6, 1, 5, 5, 7, 3, 2]
+    },
+    {
+      'identifierString': '1.3.6.1.5.5.7.1.1',
+      'readableName': 'authorityInfoAccess',
+      'identifier': [1, 3, 6, 1, 5, 5, 7, 1, 1]
+    },
+    {
+      'identifierString': '1.3.6.1.5.5.7.48.1',
+      'readableName': 'ocsp',
+      'identifier': [1, 3, 6, 1, 5, 5, 7, 48, 1]
+    },
+    {
+      'identifierString': '1.3.6.1.5.5.7.48.2',
+      'readableName': 'caIssuers',
+      'identifier': [1, 3, 6, 1, 5, 5, 7, 48, 2]
+    },
+    {
+      'identifierString': '1.2.840.113549.1.1.11',
+      'readableName': 'sha256WithRSAEncryption',
+      'identifier': [1, 2, 840, 113549, 1, 1, 11]
+    },
+    {
+      'identifierString': '1.2.840.113549.1.1.4',
+      'readableName': 'md5WithRSAEncryption',
+      'identifier': [1, 2, 840, 113549, 1, 1, 4]
+    },
+    {
+      'identifierString': '1.3.6.1.4.1.11129.2.4.2',
+      'readableName': '2',
+      'identifier': [1, 3, 6, 1, 4, 1, 11129, 2, 4, 2]
+    },
+    {
+      'identifierString': '2.23.140.1.1',
+      'readableName': 'ev-guidelines',
+      'identifier': [2, 23, 140, 1, 1]
+    },
+    {
+      'identifierString': '1.2.840.113549.1.1.5',
+      'readableName': 'sha1WithRSAEncryption',
+      'identifier': [1, 2, 840, 113549, 1, 1, 5]
+    },
+    {
+      'identifierString': '1.2.840.10045.2.1',
+      'readableName': 'ecPublicKey',
+      'identifier': [1, 2, 840, 10045, 2, 1]
+    },
+    {
+      'identifierString': '1.2.840.10045.3.1.7',
+      'readableName': 'prime256v1',
+      'identifier': [1, 2, 840, 10045, 3, 1, 7]
+    },
+    {
+      'identifierString': '1.2.840.10045.4.3.2',
+      'readableName': 'ecdsaWithSHA256',
+      'identifier': [1, 2, 840, 10045, 4, 3, 2]
+    },
+    {
+      'identifierString': '2.5.4.3',
+      'readableName': 'CN',
+      'identifier': [2, 5, 4, 3]
+    },
+    {
+      'identifierString': '2.5.4.4',
+      'readableName': 'SN',
+      'identifier': [2, 5, 4, 4]
+    },
+    {
+      'identifierString': '2.5.4.5',
+      'readableName': 'SERIALNUMBER',
+      'identifier': [2, 5, 4, 5]
+    },
+    {
+      'identifierString': '2.5.4.6',
+      'readableName': 'C',
+      'identifier': [2, 5, 4, 6]
+    },
+    {
+      'identifierString': '2.5.4.7',
+      'readableName': 'L',
+      'identifier': [2, 5, 4, 7]
+    },
+    {
+      'identifierString': '2.5.4.8',
+      'readableName': 'ST',
+      'identifier': [2, 5, 4, 8]
+    },
+    {
+      'identifierString': '2.5.4.8',
+      'readableName': 'S',
+      'identifier': [2, 5, 4, 8]
+    },
+    {
+      'identifierString': '2.5.4.9',
+      'readableName': 'streetAddress',
+      'identifier': [2, 5, 4, 9]
+    },
+    {
+      'identifierString': '2.5.4.9',
+      'readableName': 'STREET',
+      'identifier': [2, 5, 4, 9]
+    },
+    {
+      'identifierString': '2.5.4.10',
+      'readableName': 'O',
+      'identifier': [2, 5, 4, 10]
+    },
+    {
+      'identifierString': '2.5.4.11',
+      'readableName': 'OU',
+      'identifier': [2, 5, 4, 11]
+    },
+    {
+      'identifierString': '2.5.4.12',
+      'readableName': 'title',
+      'identifier': [2, 5, 4, 12]
+    },
+    {
+      'identifierString': '2.5.4.12',
+      'readableName': 'T',
+      'identifier': [2, 5, 4, 12]
+    },
+    {
+      'identifierString': '2.5.4.12',
+      'readableName': 'TITLE',
+      'identifier': [2, 5, 4, 12]
+    },
+    {
+      'identifierString': '2.5.4.42',
+      'readableName': 'givenName',
+      'identifier': [2, 5, 4, 42]
+    },
+    {
+      'identifierString': '2.5.4.42',
+      'readableName': 'G',
+      'identifier': [2, 5, 4, 42]
+    },
+    {
+      'identifierString': '2.5.4.42',
+      'readableName': 'GN',
+      'identifier': [2, 5, 4, 42]
+    },
+  ];
+
+  ///
+  /// Returns the object identifier corresponding to the given [readableName].
+  ///
+  /// Returns null if none object identifier can be found for the given [readableName].
+  ///
+  static Map<String, dynamic> getIdentifierByName(String readableName) {
+    for (var element in oi) {
+      if (element['readableName'] == readableName) {
+        return element;
+      }
+    }
+    return null;
+  }
+
+  ///
+  /// Returns the object identifier corresponding to the given [identifier].
+  ///
+  /// Returns null if none object identifier can be found for the given [identifier].
+  ///
+  static Map<String, dynamic> getIdentifierByIdentifier(String identifier) {
+    for (var element in oi) {
+      if (element['identifierString'] == identifier) {
+        return element;
+      }
+    }
+    return null;
+  }
+}

--- a/lib/bitcoincash/src/encoding/asn1/primitives/asn1_bit_string.dart
+++ b/lib/bitcoincash/src/encoding/asn1/primitives/asn1_bit_string.dart
@@ -1,0 +1,146 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import '../asn1_encoding_rule.dart';
+import '../asn1_object.dart';
+import '../asn1_parser.dart';
+import '../asn1_tags.dart';
+import '../asn1_utils.dart';
+import '../unsupported_asn1_encoding_rule_exception.dart';
+
+///
+/// An ASN1 Bit String object
+///
+class ASN1BitString extends ASN1Object {
+  ///
+  /// The decoded string value
+  ///
+  List<int> stringValues;
+
+  ///
+  /// The unused bits
+  ///
+  int unusedbits;
+
+  ///
+  /// A list of elements. Only set if this ASN1IA5String is constructed, otherwhise null.
+  ///
+  ///
+  List<ASN1Object> elements;
+
+  ///
+  /// Create an [ASN1BitString] entity with the given [stringValues].
+  ///
+  ASN1BitString(
+      {this.stringValues, this.elements, int tag = ASN1Tags.BIT_STRING})
+      : super(tag: tag);
+
+  ///
+  /// Creates an [ASN1BitString] entity from the given [encodedBytes].
+  ///
+  ASN1BitString.fromBytes(Uint8List bytes) : super.fromBytes(bytes) {
+    if (ASN1Utils.isConstructed(encodedBytes.elementAt(0))) {
+      elements = [];
+      var parser = ASN1Parser(valueBytes);
+      stringValues = [];
+      while (parser.hasNext()) {
+        var bitString = parser.nextObject() as ASN1BitString;
+        stringValues.addAll(bitString.stringValues);
+        elements.add(bitString);
+      }
+    } else {
+      unusedbits = valueBytes[0];
+      stringValues = valueBytes.sublist(1);
+    }
+  }
+
+  ///
+  /// Encodes this ASN1Object depending on the given [encodingRule]
+  ///
+  /// If no [ASN1EncodingRule] is given, ENCODING_DER will be used.
+  ///
+  /// Supported encoding rules are :
+  /// * [ASN1EncodingRule.ENCODING_DER]
+  /// * [ASN1EncodingRule.ENCODING_BER_LONG_LENGTH_FORM]
+  /// * [ASN1EncodingRule.ENCODING_BER_CONSTRUCTED]
+  /// * [ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH]
+  /// * [ASN1EncodingRule.ENCODING_BER_PADDED]
+  ///
+  /// Throws an [UnsupportedAsn1EncodingRuleException] if the given [encodingRule] is not supported.
+  ///
+  @override
+  Uint8List encode(
+      {ASN1EncodingRule encodingRule = ASN1EncodingRule.ENCODING_DER}) {
+    switch (encodingRule) {
+      case ASN1EncodingRule.ENCODING_BER_PADDED:
+      case ASN1EncodingRule.ENCODING_DER:
+      case ASN1EncodingRule.ENCODING_BER_LONG_LENGTH_FORM:
+        var b = <int>[];
+        if (unusedbits != null) {
+          b.add(unusedbits);
+        }
+        b.addAll(stringValues);
+        valueBytes = Uint8List.fromList(b);
+        break;
+      case ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH:
+      case ASN1EncodingRule.ENCODING_BER_CONSTRUCTED:
+        valueByteLength = 0;
+        if (elements == null) {
+          elements.add(ASN1BitString(stringValues: stringValues));
+        }
+        valueByteLength = _childLength(
+            isIndefinite: encodingRule ==
+                ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH);
+        valueBytes = Uint8List(valueByteLength);
+        var i = 0;
+        elements.forEach((obj) {
+          var b = obj.encode();
+          valueBytes.setRange(i, i + b.length, b);
+          i += b.length;
+        });
+        break;
+    }
+
+    return super.encode(encodingRule: encodingRule);
+  }
+
+  ///
+  /// Calculate encoded length of all children
+  ///
+  int _childLength({bool isIndefinite = false}) {
+    var l = 0;
+    elements.forEach((ASN1Object obj) {
+      l += obj.encode().length;
+    });
+    if (isIndefinite) {
+      return l + 2;
+    }
+    return l;
+  }
+
+  @override
+  String dump({int spaces = 0}) {
+    var sb = StringBuffer();
+    for (var i = 0; i < spaces; i++) {
+      sb.write(' ');
+    }
+    if (isConstructed) {
+      sb.write('BIT STRING (${elements.length} elem)');
+      for (var e in elements) {
+        var dump = e.dump(spaces: spaces + dumpIndent);
+        sb.write('\n$dump');
+      }
+    } else {
+      if (ASN1Utils.isASN1Tag(stringValues.elementAt(0))) {
+        var parser = ASN1Parser(stringValues);
+        var next = parser.nextObject();
+        var dump = next.dump(spaces: spaces + dumpIndent);
+        sb.write('BIT STRING\n$dump');
+      } else {
+        sb.write(
+            'BIT STRING ${ascii.decode(stringValues, allowInvalid: true)}');
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/lib/bitcoincash/src/encoding/asn1/primitives/asn1_boolean.dart
+++ b/lib/bitcoincash/src/encoding/asn1/primitives/asn1_boolean.dart
@@ -1,0 +1,69 @@
+import 'dart:typed_data';
+
+import '../asn1_encoding_rule.dart';
+import '../asn1_object.dart';
+import '../asn1_tags.dart';
+import '../unsupported_asn1_encoding_rule_exception.dart';
+
+///
+/// An ASN1 Boolean object
+///
+class ASN1Boolean extends ASN1Object {
+  bool boolValue;
+
+  ///
+  /// The byte to use for the TRUE value
+  ///
+  static const int BOOLEAN_TRUE_VALUE = 0xff;
+
+  ///
+  /// The byte to use for the FALSE value
+  ///
+  static const int BOOLEAN_FALSE_VALUE = 0x00;
+
+  ///
+  /// Creates an [ASN1Boolean] entity with the given [boolValue].
+  ///
+  ASN1Boolean(this.boolValue, {int tag = ASN1Tags.BOOLEAN}) : super(tag: tag);
+
+  ///
+  /// Creates an [ASN1Boolean] entity from the given [encodedBytes].
+  ///
+  ASN1Boolean.fromBytes(Uint8List encodedBytes)
+      : super.fromBytes(encodedBytes) {
+    boolValue = (valueBytes[0] == BOOLEAN_TRUE_VALUE);
+  }
+
+  ///
+  /// Encodes this ASN1Object depending on the given [encodingRule]
+  ///
+  /// If no [ASN1EncodingRule] is given, ENCODING_DER will be used.
+  ///
+  /// Supported encoding rules are :
+  /// * [ASN1EncodingRule.ENCODING_DER]
+  ///
+  /// Throws an [UnsupportedAsn1EncodingRuleException] if the given [encodingRule] is not supported.
+  ///
+  @override
+  Uint8List encode(
+      {ASN1EncodingRule encodingRule = ASN1EncodingRule.ENCODING_DER}) {
+    if (encodingRule != ASN1EncodingRule.ENCODING_DER) {
+      throw UnsupportedAsn1EncodingRuleException(encodingRule);
+    }
+    valueByteLength = 1;
+    valueBytes = (boolValue == true)
+        ? Uint8List.fromList([BOOLEAN_TRUE_VALUE])
+        : Uint8List.fromList([BOOLEAN_FALSE_VALUE]);
+    return super.encode();
+  }
+
+  @override
+  String dump({int spaces = 0}) {
+    var sb = StringBuffer();
+    for (var i = 0; i < spaces; i++) {
+      sb.write(' ');
+    }
+    sb.write('Boolean $boolValue');
+    return sb.toString();
+  }
+}

--- a/lib/bitcoincash/src/encoding/asn1/primitives/asn1_enumerated.dart
+++ b/lib/bitcoincash/src/encoding/asn1/primitives/asn1_enumerated.dart
@@ -1,0 +1,21 @@
+import 'dart:typed_data';
+
+import '../asn1_tags.dart';
+import '../primitives/asn1_integer.dart';
+
+///
+/// An ASN1Enumerated object
+///
+class ASN1Enumerated extends ASN1Integer {
+  ///
+  /// Create an [ASN1Enumerated] entity with the given integer [i].
+  ///
+  ASN1Enumerated(int i, {int tag = ASN1Tags.ENUMERATED})
+      : super(BigInt.from(i), tag: tag);
+
+  ///
+  /// Creates an [ASN1Enumerated] entity from the given [encodedBytes].
+  ///
+  ASN1Enumerated.fromBytes(Uint8List encodedBytes)
+      : super.fromBytes(encodedBytes);
+}

--- a/lib/bitcoincash/src/encoding/asn1/primitives/asn1_generalized_time.dart
+++ b/lib/bitcoincash/src/encoding/asn1/primitives/asn1_generalized_time.dart
@@ -1,0 +1,79 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import '../asn1_encoding_rule.dart';
+import '../asn1_object.dart';
+import '../asn1_tags.dart';
+import '../unsupported_asn1_encoding_rule_exception.dart';
+
+class ASN1GeneralizedTime extends ASN1Object {
+  // The decoded date value
+  DateTime dateTimeValue;
+
+  ///
+  /// Create an [ASN1GeneralizedTime] entity with the given BigInt [dateTimeValue].
+  ///
+  ASN1GeneralizedTime(this.dateTimeValue, {int tag = ASN1Tags.GENERALIZED_TIME})
+      : super(tag: tag);
+
+  ///
+  /// Creates an [ASN1GeneralizedTime] entity from the given [encodedBytes].
+  ///
+  ASN1GeneralizedTime.fromBytes(Uint8List bytes) : super.fromBytes(bytes) {
+    var octets = valueBytes;
+    var stringValue = ascii.decode(octets);
+    var year = stringValue.substring(0, 4);
+    var month = stringValue.substring(4, 6);
+    var day = stringValue.substring(6, 8);
+    var hour = stringValue.substring(8, 10);
+    var minute = stringValue.substring(10, 12);
+    var second = stringValue.substring(12, 14);
+    if (stringValue.length > 14) {
+      var timeZone = stringValue.substring(14, stringValue.length);
+      dateTimeValue =
+          DateTime.parse('$year-$month-$day $hour:$minute:$second$timeZone');
+    } else {
+      dateTimeValue = DateTime.parse('$year-$month-$day $hour:$minute:$second');
+    }
+  }
+
+  ///
+  /// Encodes this ASN1Object depending on the given [encodingRule]
+  ///
+  /// If no [ASN1EncodingRule] is given, ENCODING_DER will be used.
+  ///
+  /// Supported encoding rules are :
+  /// * [ASN1EncodingRule.ENCODING_DER]
+  ///
+  /// Throws an [UnsupportedAsn1EncodingRuleException] if the given [encodingRule] is not supported.
+  ///
+  @override
+  Uint8List encode(
+      {ASN1EncodingRule encodingRule = ASN1EncodingRule.ENCODING_DER}) {
+    if (encodingRule != ASN1EncodingRule.ENCODING_DER) {
+      throw UnsupportedAsn1EncodingRuleException(encodingRule);
+    }
+    var utc = dateTimeValue.toUtc();
+    var year = utc.year.toString();
+    var month = utc.month.toString();
+    var day = utc.day.toString();
+    var hour = utc.hour.toString();
+    var minute = utc.minute.toString();
+    var second = utc.second.toString();
+    // Encode string to YYMMDDhhmm[ss]Z
+    var utcString = '$year$month$day$hour$minute${second}Z';
+    valueBytes = ascii.encode(utcString);
+    valueByteLength = valueBytes.length;
+    return super.encode();
+  }
+
+  @override
+  String dump({int spaces = 0}) {
+    var sb = StringBuffer();
+    for (var i = 0; i < spaces; i++) {
+      sb.write(' ');
+    }
+    sb.write('UTCTime ${dateTimeValue.toIso8601String()}');
+    return sb.toString();
+  }
+}

--- a/lib/bitcoincash/src/encoding/asn1/primitives/asn1_ia5_string.dart
+++ b/lib/bitcoincash/src/encoding/asn1/primitives/asn1_ia5_string.dart
@@ -1,0 +1,130 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import '../asn1_encoding_rule.dart';
+import '../asn1_object.dart';
+import '../asn1_parser.dart';
+import '../asn1_tags.dart';
+import '../asn1_utils.dart';
+import '../unsupported_asn1_encoding_rule_exception.dart';
+
+///
+/// An ASN1 IA5 String object
+///
+class ASN1IA5String extends ASN1Object {
+  ///
+  /// The ascii decoded string value
+  ///
+  String stringValue;
+
+  ///
+  /// A list of elements. Only set if this ASN1IA5String is constructed, otherwhise null.
+  ///
+  List<ASN1Object> elements;
+
+  ///
+  /// Create an [ASN1IA5String] entity with the given [stringValue].
+  ///
+  ASN1IA5String(
+      {this.stringValue, this.elements, int tag = ASN1Tags.IA5_STRING})
+      : super(tag: tag);
+
+  ///
+  /// Creates an [ASN1IA5String] entity from the given [encodedBytes].
+  ///
+  ASN1IA5String.fromBytes(Uint8List encodedBytes)
+      : super.fromBytes(encodedBytes) {
+    if (ASN1Utils.isConstructed(encodedBytes.elementAt(0))) {
+      elements = [];
+      var parser = ASN1Parser(valueBytes);
+      var sb = StringBuffer();
+      while (parser.hasNext()) {
+        var ia5String = parser.nextObject() as ASN1IA5String;
+        sb.write(ia5String.stringValue);
+        elements.add(ia5String);
+      }
+      stringValue = sb.toString();
+    } else {
+      stringValue = ascii.decode(valueBytes);
+    }
+  }
+
+  ///
+  /// Encodes this ASN1Object depending on the given [encodingRule]
+  ///
+  /// If no [ASN1EncodingRule] is given, ENCODING_DER will be used.
+  ///
+  /// Supported encoding rules are :
+  /// * [ASN1EncodingRule.ENCODING_DER]
+  /// * [ASN1EncodingRule.ENCODING_BER_LONG_LENGTH_FORM]
+  /// * [ASN1EncodingRule.ENCODING_BER_CONSTRUCTED]
+  /// * [ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH]
+  ///
+  /// Throws an [UnsupportedAsn1EncodingRuleException] if the given [encodingRule] is not supported.
+  ///
+  @override
+  Uint8List encode(
+      {ASN1EncodingRule encodingRule = ASN1EncodingRule.ENCODING_DER}) {
+    switch (encodingRule) {
+      case ASN1EncodingRule.ENCODING_DER:
+      case ASN1EncodingRule.ENCODING_BER_LONG_LENGTH_FORM:
+        var octets = ascii.encode(stringValue);
+        valueByteLength = octets.length;
+        valueBytes = Uint8List.fromList(octets);
+        break;
+      case ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH:
+      case ASN1EncodingRule.ENCODING_BER_CONSTRUCTED:
+        valueByteLength = 0;
+        if (elements == null) {
+          elements.add(ASN1IA5String(stringValue: stringValue));
+        }
+        valueByteLength = _childLength(
+            isIndefinite: encodingRule ==
+                ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH);
+        valueBytes = Uint8List(valueByteLength);
+        var i = 0;
+        elements.forEach((obj) {
+          var b = obj.encode();
+          valueBytes.setRange(i, i + b.length, b);
+          i += b.length;
+        });
+        break;
+      case ASN1EncodingRule.ENCODING_BER_PADDED:
+        throw UnsupportedAsn1EncodingRuleException(encodingRule);
+    }
+
+    return super.encode(encodingRule: encodingRule);
+  }
+
+  ///
+  /// Calculate encoded length of all children
+  ///
+  int _childLength({bool isIndefinite = false}) {
+    var l = 0;
+    elements.forEach((ASN1Object obj) {
+      l += obj.encode().length;
+    });
+    if (isIndefinite) {
+      return l + 2;
+    }
+    return l;
+  }
+
+  @override
+  String dump({int spaces = 0}) {
+    var sb = StringBuffer();
+    for (var i = 0; i < spaces; i++) {
+      sb.write(' ');
+    }
+    if (isConstructed) {
+      sb.write('IA5String (${elements.length} elem)');
+      for (var e in elements) {
+        var dump = e.dump(spaces: spaces + dumpIndent);
+        sb.write('\n $dump');
+      }
+    } else {
+      sb.write('IA5String $stringValue');
+    }
+    return sb.toString();
+  }
+}

--- a/lib/bitcoincash/src/encoding/asn1/primitives/asn1_integer.dart
+++ b/lib/bitcoincash/src/encoding/asn1/primitives/asn1_integer.dart
@@ -1,0 +1,73 @@
+import 'dart:typed_data';
+
+import '../asn1_encoding_rule.dart';
+import '../asn1_object.dart';
+import '../asn1_tags.dart';
+import '../unsupported_asn1_encoding_rule_exception.dart';
+import '../asn1_utils.dart';
+
+class ASN1Integer extends ASN1Object {
+  ///
+  /// The integer value
+  ///
+  BigInt integer;
+
+  ///
+  /// Create an [ASN1Integer] entity with the given BigInt [integer].
+  ///
+  ASN1Integer(this.integer, {int tag = ASN1Tags.INTEGER}) : super(tag: tag);
+
+  ///
+  /// Create an [ASN1Integer] entity with the given int [i].
+  ///
+  ASN1Integer.fromtInt(int i, {int tag = ASN1Tags.INTEGER}) : super(tag: tag) {
+    integer = BigInt.from(i);
+  }
+
+  ///
+  /// Creates an [ASN1Integer] entity from the given [encodedBytes].
+  ///
+  ASN1Integer.fromBytes(Uint8List encodedBytes)
+      : super.fromBytes(encodedBytes) {
+    integer = ASN1Utils.decodeBigInt(valueBytes);
+  }
+
+  ///
+  /// Encodes this ASN1Object depending on the given [encodingRule]
+  ///
+  /// If no [ASN1EncodingRule] is given, ENCODING_DER will be used.
+  ///
+  /// Supported encoding rules are :
+  /// * [ASN1EncodingRule.ENCODING_DER]
+  ///
+  /// Throws an [UnsupportedAsn1EncodingRuleException] if the given [encodingRule] is not supported.
+  ///
+  @override
+  Uint8List encode(
+      {ASN1EncodingRule encodingRule = ASN1EncodingRule.ENCODING_DER}) {
+    if (encodingRule != ASN1EncodingRule.ENCODING_DER) {
+      throw UnsupportedAsn1EncodingRuleException(encodingRule);
+    }
+    if (integer.bitLength == 0) {
+      if (integer == BigInt.from(-1)) {
+        valueBytes = Uint8List.fromList([0xff]);
+      } else {
+        valueBytes = Uint8List.fromList([0]);
+      }
+    } else {
+      valueBytes = ASN1Utils.encodeBigInt(integer);
+    }
+    valueByteLength = valueBytes.length;
+    return super.encode();
+  }
+
+  @override
+  String dump({int spaces = 0}) {
+    var sb = StringBuffer();
+    for (var i = 0; i < spaces; i++) {
+      sb.write(' ');
+    }
+    sb.write('INTEGER ${integer.toString().toUpperCase()}');
+    return sb.toString();
+  }
+}

--- a/lib/bitcoincash/src/encoding/asn1/primitives/asn1_null.dart
+++ b/lib/bitcoincash/src/encoding/asn1/primitives/asn1_null.dart
@@ -1,0 +1,53 @@
+import 'dart:typed_data';
+
+import '../asn1_encoding_rule.dart';
+import '../asn1_object.dart';
+import '../asn1_tags.dart';
+import '../unsupported_asn1_encoding_rule_exception.dart';
+
+///
+/// An ASN1 Null object
+///
+class ASN1Null extends ASN1Object {
+  ///
+  /// Creates an empty [ASN1Null] entity with only the [tag] set.
+  ///
+  ASN1Null({int tag = ASN1Tags.NULL}) : super(tag: tag);
+
+  ///
+  /// Creates an [ASN1Null] entity from the given [encodedBytes].
+  ///
+  ASN1Null.fromBytes(Uint8List encodedBytes) : super.fromBytes(encodedBytes);
+
+  ///
+  /// Encode the [ASN1Null] to the byte representation.
+  ///
+  /// This basically returns **[0x05, 0x00]** or **[0x05, 0x81, 0x00]** depending on the [encodingRule] and will not call the *super.encode()* method.
+  ///
+  /// Supported encoding rules are :
+  /// * [ASN1EncodingRule.ENCODING_DER]
+  /// * [ASN1EncodingRule.ENCODING_BER_LONG_LENGTH_FORM]
+  ///
+  @override
+  Uint8List encode(
+      {ASN1EncodingRule encodingRule = ASN1EncodingRule.ENCODING_DER}) {
+    switch (encodingRule) {
+      case ASN1EncodingRule.ENCODING_DER:
+        return Uint8List.fromList([tag, 0x00]);
+      case ASN1EncodingRule.ENCODING_BER_LONG_LENGTH_FORM:
+        return Uint8List.fromList([tag, 0x81, 0x00]);
+      default:
+        throw UnsupportedAsn1EncodingRuleException(encodingRule);
+    }
+  }
+
+  @override
+  String dump({int spaces = 0}) {
+    var sb = StringBuffer();
+    for (var i = 0; i < spaces; i++) {
+      sb.write(' ');
+    }
+    sb.write('NULL');
+    return sb.toString();
+  }
+}

--- a/lib/bitcoincash/src/encoding/asn1/primitives/asn1_object_identifier.dart
+++ b/lib/bitcoincash/src/encoding/asn1/primitives/asn1_object_identifier.dart
@@ -1,0 +1,184 @@
+import 'dart:typed_data';
+
+import '../asn1_encoding_rule.dart';
+import '../asn1_object.dart';
+import '../asn1_tags.dart';
+import '../object_identifiers.dart';
+import '../unsupported_asn1_encoding_rule_exception.dart';
+import '../unsupported_object_identifier_exception.dart';
+
+class ASN1ObjectIdentifier extends ASN1Object {
+  ///
+  /// The object identifier integer values
+  ///
+  List<int> objectIdentifier;
+
+  ///
+  /// The String representation of the [objectIdentifier]
+  ///
+  String objectIdentifierAsString;
+
+  ///
+  /// The readable representation of the [objectIdentifier]
+  ///
+  String readableName;
+
+  ///
+  /// Create an [ASN1ObjectIdentifier] entity with the given [objectIdentifier].
+  ///
+  ASN1ObjectIdentifier(this.objectIdentifier,
+      {int tag = ASN1Tags.OBJECT_IDENTIFIER})
+      : super(tag: tag) {
+    objectIdentifierAsString = objectIdentifier.join('.');
+  }
+
+  ///
+  /// Creates an [ASN1ObjectIdentifier] entity from the given [encodedBytes].
+  ///
+  ASN1ObjectIdentifier.fromBytes(Uint8List encodedBytes)
+      : super.fromBytes(encodedBytes) {
+    var value = 0;
+    var first = true;
+    BigInt bigValue;
+    var list = <int>[];
+    var sb = StringBuffer();
+    valueBytes.forEach((element) {
+      var b = element & 0xff;
+      if (value < 0x80000000000000) {
+        value = value * 128 + (b & 0x7f);
+        if ((b & 0x80) == 0) {
+          if (first) {
+            var truncated = value ~/ 40;
+            if (truncated < 2) {
+              list.add(truncated);
+              sb.write(truncated);
+              value -= truncated * 40;
+            } else {
+              list.add(2);
+              sb.write('2');
+              value -= 80;
+            }
+            first = false;
+          }
+          list.add(value);
+          sb.write('.$value');
+          value = 0;
+        }
+      } else {
+        bigValue ??= BigInt.from(value);
+        bigValue = bigValue << (7);
+        bigValue = bigValue | BigInt.from(b & 0x7f);
+        if ((b & 0x80) == 0) {
+          sb.write('.$bigValue');
+          bigValue = null;
+          value = 0;
+        }
+      }
+    });
+    objectIdentifierAsString = sb.toString();
+    objectIdentifier = Uint8List.fromList(list);
+    var identifier =
+        ObjectIdentifiers.getIdentifierByIdentifier(objectIdentifierAsString);
+    if (identifier != null) {
+      readableName = identifier['readableName'] as String;
+    }
+  }
+
+  ///
+  /// Creates an [ASN1ObjectIdentifier] entity from the given [name].
+  ///
+  /// Example:
+  /// ```
+  /// var oi = ASN1ObjectIdentifier.fromName('ecdsaWithSHA256');
+  /// ```
+  ///
+  /// Throws an [UnsupportedObjectIdentifierException] if the given [name] is not supported
+  ///
+  ASN1ObjectIdentifier.fromName(String name) {
+    tag = ASN1Tags.OBJECT_IDENTIFIER;
+    var identifier = ObjectIdentifiers.getIdentifierByName(name);
+    if (identifier == null) {
+      throw UnsupportedObjectIdentifierException(name);
+    }
+    objectIdentifierAsString = identifier['identifierString'] as String;
+    readableName = identifier['readableName'] as String;
+    objectIdentifier = identifier['identifier'] as List<int>;
+  }
+
+  ///
+  /// Creates an [ASN1ObjectIdentifier] entity from the given [objectIdentifierAsString].
+  ///
+  /// Example:
+  /// ```
+  /// var oi = ASN1ObjectIdentifier.fromName('2.5.4.3');
+  /// ```
+  ///
+  /// Throws an [UnsupportedObjectIdentifierException] if the given [objectIdentifierAsString] is not supported
+  ///
+  ASN1ObjectIdentifier.fromIdentifierString(this.objectIdentifierAsString,
+      {int tag = ASN1Tags.OBJECT_IDENTIFIER})
+      : super(tag: tag) {
+    var identifier =
+        ObjectIdentifiers.getIdentifierByIdentifier(objectIdentifierAsString);
+    if (identifier == null) {
+      throw UnsupportedObjectIdentifierException(objectIdentifierAsString);
+    }
+    objectIdentifierAsString = identifier['identifierString'] as String;
+    readableName = identifier['readableName'] as String;
+    objectIdentifier = identifier['identifier'] as List<int>;
+  }
+
+  ///
+  /// Encodes this ASN1Object depending on the given [encodingRule]
+  ///
+  /// If no [ASN1EncodingRule] is given, ENCODING_DER will be used.
+  ///
+  /// Supported encoding rules are :
+  /// * [ASN1EncodingRule.ENCODING_DER]
+  ///
+  /// Throws an [UnsupportedAsn1EncodingRuleException] if the given [encodingRule] is not supported.
+  ///
+  @override
+  Uint8List encode(
+      {ASN1EncodingRule encodingRule = ASN1EncodingRule.ENCODING_DER}) {
+    if (encodingRule != ASN1EncodingRule.ENCODING_DER) {
+      throw UnsupportedAsn1EncodingRuleException(encodingRule);
+    }
+    var oi = <int>[];
+    oi.add(objectIdentifier[0] * 40 + objectIdentifier[1]);
+
+    for (var ci = 2; ci < objectIdentifier.length; ci++) {
+      var position = oi.length;
+      var v = objectIdentifier[ci];
+      assert(v > 0);
+
+      var first = true;
+      do {
+        var remainder = v & 127;
+        v = v >> 7;
+        if (first) {
+          first = false;
+        } else {
+          remainder |= 0x80;
+        }
+
+        oi.insert(position, remainder);
+      } while (v > 0);
+    }
+
+    valueBytes = Uint8List.fromList(oi);
+    valueByteLength = oi.length;
+
+    return super.encode();
+  }
+
+  @override
+  String dump({int spaces = 0}) {
+    var sb = StringBuffer();
+    for (var i = 0; i < spaces; i++) {
+      sb.write(' ');
+    }
+    sb.write('OBJECT IDENTIFIER $objectIdentifierAsString $readableName');
+    return sb.toString();
+  }
+}

--- a/lib/bitcoincash/src/encoding/asn1/primitives/asn1_octet_string.dart
+++ b/lib/bitcoincash/src/encoding/asn1/primitives/asn1_octet_string.dart
@@ -1,0 +1,135 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import '../asn1_encoding_rule.dart';
+import '../asn1_object.dart';
+import '../asn1_parser.dart';
+import '../asn1_tags.dart';
+import '../asn1_utils.dart';
+import '../unsupported_asn1_encoding_rule_exception.dart';
+
+///
+/// An ASN1 Octed String object
+///
+class ASN1OctetString extends ASN1Object {
+  ///
+  /// The decoded string value
+  ///
+  Uint8List octets;
+
+  ///
+  /// A list of elements. Only set if this ASN1OctetString is constructed, otherwhise null.
+  ///
+  List<ASN1Object> elements;
+
+  ///
+  /// Create an [ASN1OctetString] entity with the given [octets].
+  ///
+  ASN1OctetString({this.octets, this.elements, int tag = ASN1Tags.OCTET_STRING})
+      : super(tag: tag);
+
+  ///
+  /// Creates an [ASN1OctetString] entity from the given [encodedBytes].
+  ///
+  ASN1OctetString.fromBytes(Uint8List encodedBytes)
+      : super.fromBytes(encodedBytes) {
+    if (ASN1Utils.isConstructed(encodedBytes.elementAt(0))) {
+      elements = [];
+      var parser = ASN1Parser(valueBytes);
+      var bytes = <int>[];
+      while (parser.hasNext()) {
+        var octetString = parser.nextObject() as ASN1OctetString;
+        bytes.addAll(octetString.octets);
+        elements.add(octetString);
+      }
+      octets = Uint8List.fromList(bytes);
+    } else {
+      octets = valueBytes;
+    }
+  }
+
+  ///
+  /// Encodes this ASN1Object depending on the given [encodingRule]
+  ///
+  /// If no [ASN1EncodingRule] is given, ENCODING_DER will be used.
+  ///
+  /// Supported encoding rules are :
+  /// * [ASN1EncodingRule.ENCODING_DER]
+  /// * [ASN1EncodingRule.ENCODING_BER_LONG_LENGTH_FORM]
+  /// * [ASN1EncodingRule.ENCODING_BER_CONSTRUCTED]
+  /// * [ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH]
+  ///
+  /// Throws an [UnsupportedAsn1EncodingRuleException] if the given [encodingRule] is not supported.
+  ///
+  @override
+  Uint8List encode(
+      {ASN1EncodingRule encodingRule = ASN1EncodingRule.ENCODING_DER}) {
+    switch (encodingRule) {
+      case ASN1EncodingRule.ENCODING_DER:
+      case ASN1EncodingRule.ENCODING_BER_LONG_LENGTH_FORM:
+        valueByteLength = octets.length;
+        valueBytes = octets;
+        break;
+      case ASN1EncodingRule.ENCODING_BER_CONSTRUCTED:
+      case ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH:
+        valueByteLength = 0;
+        if (elements == null) {
+          elements.add(ASN1OctetString(octets: octets));
+        }
+        valueByteLength = _childLength(
+            isIndefinite: encodingRule ==
+                ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH);
+        valueBytes = Uint8List(valueByteLength);
+        var i = 0;
+        elements.forEach((obj) {
+          var b = obj.encode();
+          valueBytes.setRange(i, i + b.length, b);
+          i += b.length;
+        });
+        break;
+        break;
+      case ASN1EncodingRule.ENCODING_BER_PADDED:
+        throw UnsupportedAsn1EncodingRuleException(encodingRule);
+    }
+    return super.encode(encodingRule: encodingRule);
+  }
+
+  ///
+  /// Calculate encoded length of all children
+  ///
+  int _childLength({bool isIndefinite = false}) {
+    var l = 0;
+    elements.forEach((ASN1Object obj) {
+      l += obj.encode().length;
+    });
+    if (isIndefinite) {
+      return l + 2;
+    }
+    return l;
+  }
+
+  @override
+  String dump({int spaces = 0}) {
+    var sb = StringBuffer();
+    for (var i = 0; i < spaces; i++) {
+      sb.write(' ');
+    }
+    if (isConstructed) {
+      sb.write('OCTET STRING (${elements.length} elem)');
+      for (var e in elements) {
+        var dump = e.dump(spaces: spaces + dumpIndent);
+        sb.write('\n $dump');
+      }
+    } else {
+      if (ASN1Utils.isASN1Tag(octets.elementAt(0))) {
+        var parser = ASN1Parser(octets);
+        var next = parser.nextObject();
+        var dump = next.dump(spaces: spaces + dumpIndent);
+        sb.write('OCTET STRING\n$dump');
+      } else {
+        sb.write('OCTET STRING ${ascii.decode(octets, allowInvalid: true)}');
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/lib/bitcoincash/src/encoding/asn1/primitives/asn1_printable_string.dart
+++ b/lib/bitcoincash/src/encoding/asn1/primitives/asn1_printable_string.dart
@@ -1,0 +1,130 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import '../asn1_encoding_rule.dart';
+import '../asn1_object.dart';
+import '../asn1_parser.dart';
+import '../asn1_tags.dart';
+import '../asn1_utils.dart';
+import '../unsupported_asn1_encoding_rule_exception.dart';
+
+///
+/// An ASN1 Printable String object
+///
+class ASN1PrintableString extends ASN1Object {
+  ///
+  /// The ascii decoded string value
+  ///
+  String stringValue;
+
+  ///
+  /// A list of elements. Only set if this ASN1PrintableString is constructed, otherwhise null.
+  ///
+  List<ASN1Object> elements;
+
+  ///
+  /// Create an [ASN1PrintableString] entity with the given [stringValue].
+  ///
+  ASN1PrintableString(
+      {this.stringValue, this.elements, int tag = ASN1Tags.PRINTABLE_STRING})
+      : super(tag: tag);
+
+  ///
+  /// Creates an [ASN1PrintableString] entity from the given [encodedBytes].
+  ///
+  ASN1PrintableString.fromBytes(Uint8List encodedBytes)
+      : super.fromBytes(encodedBytes) {
+    if (ASN1Utils.isConstructed(encodedBytes.elementAt(0))) {
+      elements = [];
+      var parser = ASN1Parser(valueBytes);
+      var sb = StringBuffer();
+      while (parser.hasNext()) {
+        var printableString = parser.nextObject() as ASN1PrintableString;
+        sb.write(printableString.stringValue);
+        elements.add(printableString);
+      }
+      stringValue = sb.toString();
+    } else {
+      stringValue = ascii.decode(valueBytes);
+    }
+  }
+
+  ///
+  /// Encodes this ASN1Object depending on the given [encodingRule]
+  ///
+  /// If no [ASN1EncodingRule] is given, ENCODING_DER will be used.
+  ///
+  /// Supported encoding rules are :
+  /// * [ASN1EncodingRule.ENCODING_DER]
+  /// * [ASN1EncodingRule.ENCODING_BER_LONG_LENGTH_FORM]
+  /// * [ASN1EncodingRule.ENCODING_BER_CONSTRUCTED]
+  /// * [ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH]
+  ///
+  /// Throws an [UnsupportedAsn1EncodingRuleException] if the given [encodingRule] is not supported.
+  ///
+  @override
+  Uint8List encode(
+      {ASN1EncodingRule encodingRule = ASN1EncodingRule.ENCODING_DER}) {
+    switch (encodingRule) {
+      case ASN1EncodingRule.ENCODING_DER:
+      case ASN1EncodingRule.ENCODING_BER_LONG_LENGTH_FORM:
+        var octets = ascii.encode(stringValue);
+        valueByteLength = octets.length;
+        valueBytes = Uint8List.fromList(octets);
+        break;
+      case ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH:
+      case ASN1EncodingRule.ENCODING_BER_CONSTRUCTED:
+        valueByteLength = 0;
+        if (elements == null) {
+          elements.add(ASN1PrintableString(stringValue: stringValue));
+        }
+        valueByteLength = _childLength(
+            isIndefinite: encodingRule ==
+                ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH);
+        valueBytes = Uint8List(valueByteLength);
+        var i = 0;
+        elements.forEach((obj) {
+          var b = obj.encode();
+          valueBytes.setRange(i, i + b.length, b);
+          i += b.length;
+        });
+        break;
+      case ASN1EncodingRule.ENCODING_BER_PADDED:
+        throw UnsupportedAsn1EncodingRuleException(encodingRule);
+    }
+
+    return super.encode(encodingRule: encodingRule);
+  }
+
+  ///
+  /// Calculate encoded length of all children
+  ///
+  int _childLength({bool isIndefinite = false}) {
+    var l = 0;
+    elements.forEach((ASN1Object obj) {
+      l += obj.encode().length;
+    });
+    if (isIndefinite) {
+      return l + 2;
+    }
+    return l;
+  }
+
+  @override
+  String dump({int spaces = 0}) {
+    var sb = StringBuffer();
+    for (var i = 0; i < spaces; i++) {
+      sb.write(' ');
+    }
+    if (isConstructed) {
+      sb.write('PrintableString (${elements.length} elem)');
+      for (var e in elements) {
+        var dump = e.dump(spaces: spaces + dumpIndent);
+        sb.write('\n$dump');
+      }
+    } else {
+      sb.write('PrintableString $stringValue');
+    }
+    return sb.toString();
+  }
+}

--- a/lib/bitcoincash/src/encoding/asn1/primitives/asn1_sequence.dart
+++ b/lib/bitcoincash/src/encoding/asn1/primitives/asn1_sequence.dart
@@ -1,0 +1,95 @@
+import 'dart:typed_data';
+
+import '../asn1_encoding_rule.dart';
+import '../asn1_object.dart';
+import '../asn1_parser.dart';
+import '../asn1_tags.dart';
+import '../unsupported_asn1_encoding_rule_exception.dart';
+
+class ASN1Sequence extends ASN1Object {
+  ///
+  /// The decoded string value
+  ///
+  List<ASN1Object> elements = [];
+
+  ///
+  /// Create an [ASN1Sequence] entity with the given [elements].
+  ///
+  ASN1Sequence({this.elements, int tag = ASN1Tags.SEQUENCE}) : super(tag: tag);
+
+  ///
+  /// Creates an [ASN1Sequence] entity from the given [encodedBytes].
+  ///
+  ASN1Sequence.fromBytes(Uint8List encodedBytes)
+      : super.fromBytes(encodedBytes) {
+    elements = [];
+    var parser = ASN1Parser(valueBytes);
+    while (parser.hasNext()) {
+      elements.add(parser.nextObject());
+    }
+  }
+
+  ///
+  /// Encodes this ASN1Object depending on the given [encodingRule]
+  ///
+  /// If no [ASN1EncodingRule] is given, ENCODING_DER will be used.
+  ///
+  /// Supported encoding rules are :
+  /// * [ASN1EncodingRule.ENCODING_DER]
+  ///
+  /// Throws an [UnsupportedAsn1EncodingRuleException] if the given [encodingRule] is not supported.
+  ///
+  @override
+  Uint8List encode(
+      {ASN1EncodingRule encodingRule = ASN1EncodingRule.ENCODING_DER}) {
+    if (encodingRule != ASN1EncodingRule.ENCODING_DER) {
+      throw UnsupportedAsn1EncodingRuleException(encodingRule);
+    }
+    valueBytes = Uint8List(0);
+    valueByteLength = 0;
+    if (elements != null) {
+      valueByteLength = _childLength();
+      valueBytes = Uint8List(valueByteLength);
+      var i = 0;
+      elements.forEach((obj) {
+        var b = obj.encode();
+        valueBytes.setRange(i, i + b.length, b);
+        i += b.length;
+      });
+    }
+    return super.encode();
+  }
+
+  ///
+  /// Calculate encoded length of all children
+  ///
+  int _childLength() {
+    var l = 0;
+    elements.forEach((ASN1Object obj) {
+      l += obj.encode().length;
+    });
+    return l;
+  }
+
+  ///
+  /// Adds the given [obj] to the [elements] list.
+  ///
+  void add(ASN1Object obj) {
+    elements ??= [];
+    elements.add(obj);
+  }
+
+  @override
+  String dump({int spaces = 0}) {
+    var sb = StringBuffer();
+    for (var i = 0; i < spaces; i++) {
+      sb.write(' ');
+    }
+    sb.write('SEQUENCE (${elements.length} elem)');
+    for (var e in elements) {
+      var dump = e.dump(spaces: spaces + dumpIndent);
+      sb.write('\n$dump');
+    }
+    return sb.toString();
+  }
+}

--- a/lib/bitcoincash/src/encoding/asn1/primitives/asn1_set.dart
+++ b/lib/bitcoincash/src/encoding/asn1/primitives/asn1_set.dart
@@ -1,0 +1,94 @@
+import 'dart:typed_data';
+
+import '../asn1_encoding_rule.dart';
+import '../asn1_object.dart';
+import '../asn1_parser.dart';
+import '../asn1_tags.dart';
+import '../unsupported_asn1_encoding_rule_exception.dart';
+
+class ASN1Set extends ASN1Object {
+  ///
+  /// The decoded string value
+  ///
+  List<ASN1Object> elements;
+
+  ///
+  /// Create an [ASN1Set] entity with the given [elements].
+  ///
+  ASN1Set({this.elements, int tag = ASN1Tags.SET}) : super(tag: tag);
+
+  ///
+  /// Creates an [ASN1Set] entity from the given [encodedBytes].
+  ///
+  ASN1Set.fromBytes(Uint8List encodedBytes) : super.fromBytes(encodedBytes) {
+    elements = [];
+    var parser = ASN1Parser(valueBytes);
+    while (parser.hasNext()) {
+      elements.add(parser.nextObject());
+    }
+  }
+
+  ///
+  /// Encodes this ASN1Object depending on the given [encodingRule]
+  ///
+  /// If no [ASN1EncodingRule] is given, ENCODING_DER will be used.
+  ///
+  /// Supported encoding rules are :
+  /// * [ASN1EncodingRule.ENCODING_DER]
+  ///
+  /// Throws an [UnsupportedAsn1EncodingRuleException] if the given [encodingRule] is not supported.
+  ///
+  @override
+  Uint8List encode(
+      {ASN1EncodingRule encodingRule = ASN1EncodingRule.ENCODING_DER}) {
+    if (encodingRule != ASN1EncodingRule.ENCODING_DER) {
+      throw UnsupportedAsn1EncodingRuleException(encodingRule);
+    }
+    valueBytes = Uint8List(0);
+    valueByteLength = 0;
+    if (elements != null) {
+      valueByteLength = _childLength();
+      valueBytes = Uint8List(valueByteLength);
+      var i = 0;
+      elements.forEach((obj) {
+        var b = obj.encode();
+        valueBytes.setRange(i, i + b.length, b);
+        i += b.length;
+      });
+    }
+    return super.encode();
+  }
+
+  ///
+  /// Calculate encoded length of all children
+  ///
+  int _childLength() {
+    var l = 0;
+    elements.forEach((ASN1Object obj) {
+      l += obj.encode().length;
+    });
+    return l;
+  }
+
+  ///
+  /// Adds the given [obj] to the [elements] list.
+  ///
+  void add(ASN1Object obj) {
+    elements ??= [];
+    elements.add(obj);
+  }
+
+  @override
+  String dump({int spaces = 0}) {
+    var sb = StringBuffer();
+    for (var i = 0; i < spaces; i++) {
+      sb.write(' ');
+    }
+    sb.write('SEQUENCE (${elements.length} elem)');
+    for (var e in elements) {
+      var dump = e.dump(spaces: spaces + dumpIndent);
+      sb.write('\n$dump');
+    }
+    return sb.toString();
+  }
+}

--- a/lib/bitcoincash/src/encoding/asn1/primitives/asn1_teletext_string.dart
+++ b/lib/bitcoincash/src/encoding/asn1/primitives/asn1_teletext_string.dart
@@ -1,0 +1,130 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import '../asn1_encoding_rule.dart';
+import '../asn1_object.dart';
+import '../asn1_parser.dart';
+import '../asn1_tags.dart';
+import '../asn1_utils.dart';
+import '../unsupported_asn1_encoding_rule_exception.dart';
+
+///
+/// An ASN1 Octed String object
+///
+class ASN1TeletextString extends ASN1Object {
+  ///
+  /// The ascii decoded string value
+  ///
+  String stringValue;
+
+  ///
+  /// A list of elements. Only set if this ASN1TeletextString is constructed, otherwhise null.
+  ///
+  List<ASN1Object> elements;
+
+  ///
+  /// Create an [ASN1TeletextString] entity with the given [stringValue].
+  ///
+  ASN1TeletextString(
+      {this.stringValue, this.elements, int tag = ASN1Tags.T61_STRING})
+      : super(tag: tag);
+
+  ///
+  /// Creates an [ASN1TeletextString] entity from the given [encodedBytes].
+  ///
+  ASN1TeletextString.fromBytes(Uint8List encodedBytes)
+      : super.fromBytes(encodedBytes) {
+    if (ASN1Utils.isConstructed(encodedBytes.elementAt(0))) {
+      elements = [];
+      var parser = ASN1Parser(valueBytes);
+      var sb = StringBuffer();
+      while (parser.hasNext()) {
+        var printableString = parser.nextObject() as ASN1TeletextString;
+        sb.write(printableString.stringValue);
+        elements.add(printableString);
+      }
+      stringValue = sb.toString();
+    } else {
+      stringValue = ascii.decode(valueBytes);
+    }
+  }
+
+  ///
+  /// Encodes this ASN1Object depending on the given [encodingRule]
+  ///
+  /// If no [ASN1EncodingRule] is given, ENCODING_DER will be used.
+  ///
+  /// Supported encoding rules are :
+  /// * [ASN1EncodingRule.ENCODING_DER]
+  /// * [ASN1EncodingRule.ENCODING_BER_LONG_LENGTH_FORM]
+  /// * [ASN1EncodingRule.ENCODING_BER_CONSTRUCTED]
+  /// * [ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH]
+  ///
+  /// Throws an [UnsupportedAsn1EncodingRuleException] if the given [encodingRule] is not supported.
+  ///
+  @override
+  Uint8List encode(
+      {ASN1EncodingRule encodingRule = ASN1EncodingRule.ENCODING_DER}) {
+    switch (encodingRule) {
+      case ASN1EncodingRule.ENCODING_DER:
+      case ASN1EncodingRule.ENCODING_BER_LONG_LENGTH_FORM:
+        var octets = ascii.encode(stringValue);
+        valueByteLength = octets.length;
+        valueBytes = Uint8List.fromList(octets);
+        break;
+      case ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH:
+      case ASN1EncodingRule.ENCODING_BER_CONSTRUCTED:
+        valueByteLength = 0;
+        if (elements == null) {
+          elements.add(ASN1TeletextString(stringValue: stringValue));
+        }
+        valueByteLength = _childLength(
+            isIndefinite: encodingRule ==
+                ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH);
+        valueBytes = Uint8List(valueByteLength);
+        var i = 0;
+        elements.forEach((obj) {
+          var b = obj.encode();
+          valueBytes.setRange(i, i + b.length, b);
+          i += b.length;
+        });
+        break;
+      case ASN1EncodingRule.ENCODING_BER_PADDED:
+        throw UnsupportedAsn1EncodingRuleException(encodingRule);
+    }
+
+    return super.encode(encodingRule: encodingRule);
+  }
+
+  ///
+  /// Calculate encoded length of all children
+  ///
+  int _childLength({bool isIndefinite = false}) {
+    var l = 0;
+    elements.forEach((ASN1Object obj) {
+      l += obj.encode().length;
+    });
+    if (isIndefinite) {
+      return l + 2;
+    }
+    return l;
+  }
+
+  @override
+  String dump({int spaces = 0}) {
+    var sb = StringBuffer();
+    for (var i = 0; i < spaces; i++) {
+      sb.write(' ');
+    }
+    if (isConstructed) {
+      sb.write('T61String (${elements.length} elem)');
+      for (var e in elements) {
+        var dump = e.dump(spaces: spaces + dumpIndent);
+        sb.write('\n $dump');
+      }
+    } else {
+      sb.write('T61String $stringValue');
+    }
+    return sb.toString();
+  }
+}

--- a/lib/bitcoincash/src/encoding/asn1/primitives/asn1_utc_time.dart
+++ b/lib/bitcoincash/src/encoding/asn1/primitives/asn1_utc_time.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import '../asn1_encoding_rule.dart';
+import '../asn1_object.dart';
+import '../asn1_tags.dart';
+import '../unsupported_asn1_encoding_rule_exception.dart';
+
+///
+/// An ASN1 Utc Time object
+///
+/// **Note**: It is not recommended to use the UTC Time in the far future because this will not work anymore after the year 2075,
+/// due to the fact that the UTC Time only uses 2 digits to represent the year.!
+///
+/// Use the **GeneralizedTime** instead!
+///
+class ASN1UtcTime extends ASN1Object {
+  ///
+  /// The decoded DateTime value
+  ///
+  DateTime time;
+
+  ///
+  /// Creates an [ASN1UtcTime] entity with the given [time].
+  ///
+  ASN1UtcTime(this.time, {int tag = ASN1Tags.UTC_TIME}) : super(tag: tag);
+
+  ///
+  /// Creates an [ASN1UtcTime] entity from the given [encodedBytes].
+  ///
+  ASN1UtcTime.fromBytes(Uint8List encodedBytes)
+      : super.fromBytes(encodedBytes) {
+    var stringValue = ascii.decode(valueBytes);
+    var formatedStringValue = _format(stringValue);
+    time = DateTime.parse(formatedStringValue);
+  }
+
+  ///
+  /// Encodes this ASN1Object depending on the given [encodingRule]
+  ///
+  /// If no [ASN1EncodingRule] is given, ENCODING_DER will be used.
+  ///
+  /// Supported encoding rules are :
+  /// * [ASN1EncodingRule.ENCODING_DER]
+  ///
+  /// Throws an [UnsupportedAsn1EncodingRuleException] if the given [encodingRule] is not supported.
+  ///
+  @override
+  Uint8List encode(
+      {ASN1EncodingRule encodingRule = ASN1EncodingRule.ENCODING_DER}) {
+    if (encodingRule != ASN1EncodingRule.ENCODING_DER) {
+      throw UnsupportedAsn1EncodingRuleException(encodingRule);
+    }
+    var utc = time.toUtc();
+    var year = utc.year.toString().substring(2).padLeft(2, '0');
+    var month = utc.month.toString().padLeft(2, '0');
+    var day = utc.day.toString().padLeft(2, '0');
+    var hour = utc.hour.toString().padLeft(2, '0');
+    var minute = utc.minute.toString().padLeft(2, '0');
+    var second = utc.second.toString().padLeft(2, '0');
+    // Encode string to YYMMDDhhmm[ss]Z
+    var utcString = '$year$month$day$hour$minute${second}Z';
+    valueBytes = ascii.encode(utcString);
+    valueByteLength = valueBytes.length;
+    return super.encode();
+  }
+
+  ///
+  /// Formats the given [stringValue].
+  ///
+  /// This needs to be done, due to the fact that the UTC Time only uses 2 digits to represent the year.
+  /// To use the DateTime.parse() method we have to add the century.
+  ///
+  /// **Note**: It is not recommended to use the UTC Time in the future because this will not work anymore after the year 2075! Use the GeneralizedTime instead.
+  ///
+  String _format(String stringValue) {
+    var y2 = int.parse(stringValue.substring(0, 2));
+    if (y2 > 75) {
+      stringValue = '19' + stringValue;
+    } else {
+      stringValue = '20' + stringValue;
+    }
+    return stringValue.substring(0, 8) + 'T' + stringValue.substring(8);
+  }
+
+  @override
+  String dump({int spaces = 0}) {
+    var sb = StringBuffer();
+    for (var i = 0; i < spaces; i++) {
+      sb.write(' ');
+    }
+    sb.write('UTCTime ${time.toIso8601String()}');
+    return sb.toString();
+  }
+}

--- a/lib/bitcoincash/src/encoding/asn1/primitives/asn1_utf8_string.dart
+++ b/lib/bitcoincash/src/encoding/asn1/primitives/asn1_utf8_string.dart
@@ -1,0 +1,130 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import '../asn1_encoding_rule.dart';
+import '../asn1_object.dart';
+import '../asn1_parser.dart';
+import '../asn1_tags.dart';
+import '../asn1_utils.dart';
+import '../unsupported_asn1_encoding_rule_exception.dart';
+
+///
+/// An ASN1 UTF8 String object
+///
+class ASN1UTF8String extends ASN1Object {
+  ///
+  /// The decoded string value
+  ///
+  String utf8StringValue;
+
+  ///
+  /// A list of elements. Only set if this ASN1UTF8String is constructed, otherwhise null.
+  ///
+  List<ASN1Object> elements;
+
+  ///
+  /// Creates an empty [ASN1UTF8String] entity with only the [tag] set.
+  ///
+  ASN1UTF8String(
+      {this.utf8StringValue, this.elements, int tag = ASN1Tags.UTF8_STRING})
+      : super(tag: tag);
+
+  ///
+  /// Creates an [ASN1UTF8String] entity from the given [encodedBytes].
+  ///
+  ASN1UTF8String.fromBytes(Uint8List encodedBytes)
+      : super.fromBytes(encodedBytes) {
+    if (ASN1Utils.isConstructed(encodedBytes.elementAt(0))) {
+      elements = [];
+      var parser = ASN1Parser(valueBytes);
+      var sb = StringBuffer();
+      while (parser.hasNext()) {
+        var utf8String = parser.nextObject() as ASN1UTF8String;
+        sb.write(utf8String.utf8StringValue);
+        elements.add(utf8String);
+      }
+      utf8StringValue = sb.toString();
+    } else {
+      utf8StringValue = utf8.decode(valueBytes);
+    }
+  }
+
+  ///
+  /// Encodes this ASN1Object depending on the given [encodingRule]
+  ///
+  /// If no [ASN1EncodingRule] is given, ENCODING_DER will be used.
+  ///
+  /// Supported encoding rules are :
+  /// * [ASN1EncodingRule.ENCODING_DER]
+  /// * [ASN1EncodingRule.ENCODING_BER_LONG_LENGTH_FORM]
+  /// * [ASN1EncodingRule.ENCODING_BER_CONSTRUCTED]
+  /// * [ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH]
+  ///
+  /// Throws an [UnsupportedAsn1EncodingRuleException] if the given [encodingRule] is not supported.
+  ///
+  @override
+  Uint8List encode(
+      {ASN1EncodingRule encodingRule = ASN1EncodingRule.ENCODING_DER}) {
+    switch (encodingRule) {
+      case ASN1EncodingRule.ENCODING_DER:
+      case ASN1EncodingRule.ENCODING_BER_LONG_LENGTH_FORM:
+        var octets = utf8.encode(utf8StringValue);
+        valueByteLength = octets.length;
+        valueBytes = Uint8List.fromList(octets);
+        break;
+      case ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH:
+      case ASN1EncodingRule.ENCODING_BER_CONSTRUCTED:
+        valueByteLength = 0;
+        if (elements == null) {
+          elements.add(ASN1UTF8String(utf8StringValue: utf8StringValue));
+        }
+        valueByteLength = _childLength(
+            isIndefinite: encodingRule ==
+                ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH);
+        valueBytes = Uint8List(valueByteLength);
+        var i = 0;
+        elements.forEach((obj) {
+          var b = obj.encode();
+          valueBytes.setRange(i, i + b.length, b);
+          i += b.length;
+        });
+        break;
+      case ASN1EncodingRule.ENCODING_BER_PADDED:
+        throw UnsupportedAsn1EncodingRuleException(encodingRule);
+    }
+
+    return super.encode(encodingRule: encodingRule);
+  }
+
+  ///
+  /// Calculate encoded length of all children
+  ///
+  int _childLength({bool isIndefinite = false}) {
+    var l = 0;
+    elements.forEach((ASN1Object obj) {
+      l += obj.encode().length;
+    });
+    if (isIndefinite) {
+      return l + 2;
+    }
+    return l;
+  }
+
+  @override
+  String dump({int spaces = 0}) {
+    var sb = StringBuffer();
+    for (var i = 0; i < spaces; i++) {
+      sb.write(' ');
+    }
+    if (isConstructed) {
+      sb.write('UTF8String (${elements.length} elem)');
+      for (var e in elements) {
+        var dump = e.dump(spaces: spaces + dumpIndent);
+        sb.write('\n$dump');
+      }
+    } else {
+      sb.write('UTF8String $utf8StringValue');
+    }
+    return sb.toString();
+  }
+}

--- a/lib/bitcoincash/src/encoding/asn1/unsupported_asn1_encoding_rule_exception.dart
+++ b/lib/bitcoincash/src/encoding/asn1/unsupported_asn1_encoding_rule_exception.dart
@@ -1,0 +1,14 @@
+import './asn1_encoding_rule.dart';
+
+///
+/// Exception that indicates that the given [ASN1EncodingRule] is not supported
+///
+class UnsupportedAsn1EncodingRuleException implements Exception {
+  ASN1EncodingRule rule;
+
+  UnsupportedAsn1EncodingRuleException(this.rule);
+
+  @override
+  String toString() =>
+      'UnsupportedAsn1EncodingRuleException: Encoding $rule is not supported by this ASN1Object.';
+}

--- a/lib/bitcoincash/src/encoding/asn1/unsupported_asn1_tag_exception.dart
+++ b/lib/bitcoincash/src/encoding/asn1/unsupported_asn1_tag_exception.dart
@@ -1,0 +1,12 @@
+///
+/// Exception that indicates that the given tag is not supported
+///
+class UnsupportedASN1TagException implements Exception {
+  int tag;
+
+  UnsupportedASN1TagException(this.tag);
+
+  @override
+  String toString() =>
+      'UnsupportedASN1TagException: Tag $tag is not supported yet';
+}

--- a/lib/bitcoincash/src/encoding/asn1/unsupported_object_identifier_exception.dart
+++ b/lib/bitcoincash/src/encoding/asn1/unsupported_object_identifier_exception.dart
@@ -1,0 +1,12 @@
+///
+/// Exception that indicates that the given object identifier is not supported
+///
+class UnsupportedObjectIdentifierException implements Exception {
+  String oiString;
+
+  UnsupportedObjectIdentifierException(this.oiString);
+
+  @override
+  String toString() =>
+      'UnsupportedObjectIdentifierException: ObjectIdentifier $oiString is not supported yet';
+}

--- a/lib/bitcoincash/src/signature.dart
+++ b/lib/bitcoincash/src/signature.dart
@@ -12,6 +12,7 @@ import 'package:pointycastle/signers/ecdsa_signer.dart';
 import 'package:pointycastle/pointycastle.dart';
 // import 'package:asn1lib/asn1lib.dart';
 import 'package:hex/hex.dart';
+import './encoding/asn1.dart' as asn1;
 
 import 'exceptions.dart';
 
@@ -224,9 +225,9 @@ class BCHSignature {
 
   /// Renders the signature as a DER-encoded byte buffer
   List<int> toDER() {
-    var seq = ASN1Sequence();
-    seq.add(ASN1Integer(_r));
-    seq.add(ASN1Integer(_s));
+    var seq = asn1.ASN1Sequence();
+    seq.add(asn1.ASN1Integer(_r));
+    seq.add(asn1.ASN1Integer(_s));
 
     return seq.encode();
   }
@@ -437,10 +438,10 @@ class BCHSignature {
     try {
       var parser = ASN1Parser(HEX.decode(derBuffer));
 
-      var seq = parser.nextObject() as ASN1Sequence;
+      var seq = parser.nextObject() as asn1.ASN1Sequence;
 
-      var rVal = seq.elements[0] as ASN1Integer;
-      var sVal = seq.elements[1] as ASN1Integer;
+      var rVal = seq.elements[0] as asn1.ASN1Integer;
+      var sVal = seq.elements[1] as asn1.ASN1Integer;
 
       _rHex = HEX.encode(rVal.valueBytes);
       _sHex = HEX.encode(sVal.valueBytes);


### PR DESCRIPTION
There is a bug in pointycastle ASN utils that causes BigInts to be
serialized incorrectly if the first byte has 0x80 set. (Indicating that
it is negative). Since this particular portion of the pointycastle lib
is relatively independet, and only used in a few places in our codebase,
I am temporarily forking it until we can get the fix upstreamed.