### PR TITLE
Print electrum error to console

### DIFF
--- a/lib/wallet/wallet.dart
+++ b/lib/wallet/wallet.dart
@@ -229,7 +229,12 @@ class Wallet {
     final transactionHex = transaction.serialize();
     final client = await clientFuture;
 
-    await client.blockchainTransactionBroadcast(transactionHex);
+    try {
+      await client.blockchainTransactionBroadcast(transactionHex);
+    } catch (err) {
+      print(err.message);
+      throw err;
+    }
     return transaction;
   }
 }


### PR DESCRIPTION
As per title. Print electrum error to console when attempting to
broadcast the transaction.