### PR TITLE
Ensure send screen has the wallet, and shows an error on send failure

### DIFF
--- a/lib/tabs/send/send.dart
+++ b/lib/tabs/send/send.dart
@@ -37,8 +37,8 @@ class _SendTabState extends State<SendTab> {
 
     // WE don't want to be redrawing
     final viewModel = Provider.of<SendModel>(context, listen: false);
-    final balanceNotifier =
-        Provider.of<WalletModel>(context, listen: false).balance;
+    final walletModel = Provider.of<WalletModel>(context, listen: false);
+    final balanceNotifier = walletModel.balance;
 
     final overlay = QrScannerOverlayShape(
       borderColor: Colors.green,
@@ -73,7 +73,8 @@ class _SendTabState extends State<SendTab> {
         valueListenable: showSendInfoScreen,
         builder: (context, shouldShowSendInfoScreen, child) => Scaffold(
             body: shouldShowSendInfoScreen
-                ? SendInfo(visible: showSendInfoScreen)
+                ? SendInfo(
+                    visible: showSendInfoScreen, wallet: walletModel.wallet)
                 : Scaffold(
                     body: Stack(alignment: Alignment.center, children: [
                       Container(

--- a/lib/tabs/send/send_info.dart
+++ b/lib/tabs/send/send_info.dart
@@ -13,8 +13,20 @@ Future showReceipt(BuildContext context, Transaction transaction) {
       context: context,
       builder: (BuildContext context) {
         return AlertDialog(
-          title: const Text('Receipt'),
-          content: Text('TODO'),
+          title: const Text('Transaction sent'),
+          content: Text(transaction.id),
+        );
+      });
+}
+
+Future showError(BuildContext context, String errMessage) {
+  // TODO: Create nice looking receipt dialog.
+  return showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Error sending...'),
+          content: Text(errMessage),
         );
       });
 }
@@ -23,7 +35,7 @@ class SendInfo extends StatelessWidget {
   final ValueNotifier<bool> visible;
   final Wallet wallet;
 
-  SendInfo({this.visible, this.wallet});
+  SendInfo({this.visible, @required this.wallet});
 
   void sendButtonClicked(BuildContext context, String address, int amount) {
     final primaryValidation = (amount != null && amount > 0);
@@ -34,7 +46,8 @@ class SendInfo extends StatelessWidget {
     // somehow to indicate the address is bad.
     wallet
         .sendTransaction(Address(address), BigInt.from(amount))
-        .then((transaction) => showReceipt(context, transaction));
+        .then((transaction) => showReceipt(context, transaction))
+        .catchError((error) => showError(context, error.toString()));
   }
 
   @override


### PR DESCRIPTION
In a previous change, we stopped passing down the wallet properly to
the send_info screen. Also, it has never properly shown error dialogs.
This commit fixes both those issues. There are some problems with
transaction construction that need to be fixed still.