### PR TITLE
Bump fee to be in line with current BCHA network policies

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -10,7 +10,7 @@ const electrumUrls = [
 
 const inputSize = 148;
 const outputSize = 34;
-const defaultFeePerByte = 1.5;
+const defaultFeePerByte = 10;
 
 // UI constants
 const stdElevation =


### PR DESCRIPTION
Currently, due to the price of BCHA depreciating, the fee as increased
from 1 to 10 sats/byte. This commit updates the default to be in line
with those policies.