### PR TITLE
Fix balance calculation in vault code

### DIFF
--- a/lib/wallet/vault.dart
+++ b/lib/wallet/vault.dart
@@ -101,7 +101,14 @@ class Vault {
   }
 
   BigInt calculateBalance() {
-    return _pool.keys.fold(BigInt.zero, (p, c) => p + c);
+    return _pool.values.fold(
+        BigInt.zero,
+        (p, c) =>
+            p +
+            c.fold(
+                BigInt.zero,
+                (totalOutputs, output) =>
+                    totalOutputs + output.outpoint.amount));
   }
 
   /// Collect enough utxos to cover the [amount] and any additional fees.


### PR DESCRIPTION
The balance calculation in the vault code incorrectly assumes there
is one of each UTXO amount. When, in fact, there could be zero, or N.
In either of these cases, the current balance calculation code is
incorrect. This fixes it by properly folding the balances of each
sublist.