### PR TITLE
Standardize settings screen padding

### DIFF
--- a/lib/tabs/settings.dart
+++ b/lib/tabs/settings.dart
@@ -188,49 +188,43 @@ class SettingsTab extends StatelessWidget {
       );
     }
 
-    return Column(
-      children: [
-        Padding(
-          child: balanceCard,
-          padding: MediaQuery.of(context).padding,
-        ),
-        Row(
-          children: [
-            Expanded(
-              child: Padding(
-                padding: stdPadding,
-                child: RaisedButton(
-                  color: Colors.blue,
-                  elevation: stdElevation,
-                  onPressed: () => showSeedDialog(),
-                  child: Text(
-                    'Show Seed',
-                    style: TextStyle(color: Colors.white),
-                  ),
+    return SafeArea(
+        child: Padding(
+            padding: stdPadding,
+            child: Column(
+              children: [
+                balanceCard,
+                Row(
+                  children: [
+                    Expanded(
+                      child: RaisedButton(
+                        color: Colors.blue,
+                        elevation: stdElevation,
+                        onPressed: () => showSeedDialog(),
+                        child: Text(
+                          'Show Seed',
+                          style: TextStyle(color: Colors.white),
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
-              ),
-            ),
-          ],
-        ),
-        Row(
-          children: [
-            Expanded(
-              child: Padding(
-                padding: EdgeInsets.fromLTRB(6, 6, 6, 24),
-                child: RaisedButton(
-                  color: Colors.blue,
-                  elevation: stdElevation,
-                  onPressed: () => showEnterSeedDialog(),
-                  child: Text(
-                    'Import Seed',
-                    style: TextStyle(color: Colors.white),
-                  ),
-                ),
-              ),
-            ),
-          ],
-        )
-      ],
-    );
+                Row(
+                  children: [
+                    Expanded(
+                      child: RaisedButton(
+                        color: Colors.blue,
+                        elevation: stdElevation,
+                        onPressed: () => showEnterSeedDialog(),
+                        child: Text(
+                          'Import Seed',
+                          style: TextStyle(color: Colors.white),
+                        ),
+                      ),
+                    ),
+                  ],
+                )
+              ],
+            )));
   }
 }


### PR DESCRIPTION
Due to not understanding what `SafeArea` was previously, we had fiddled
with the padding on this screen manually. This resulted in buttons which
in some cases were different widths. This commit cleans that up and
adds back the standard bordering for the screen.