### PR TITLE
Redesign SendInfo screen to have a better input method for amounts

### DIFF
--- a/lib/components/calculator_keyboard/button_definitions.dart
+++ b/lib/components/calculator_keyboard/button_definitions.dart
@@ -1,0 +1,184 @@
+import 'package:flutter/material.dart';
+import 'calculator.dart';
+
+enum CalculatorItem {
+  ZERO,
+  ONE,
+  TWO,
+  THREE,
+  FOUR,
+  FIVE,
+  SIX,
+  SEVEN,
+  EIGHT,
+  NINE,
+  PERIOD,
+  MULTIPLY,
+  SUBTRACT,
+  ADD,
+  DIVIDE,
+  BACKSPACE,
+  EQUAL,
+  ZEROZERO,
+  CLEAR,
+  BLANK,
+}
+
+final CalculatorRows = [
+  [
+    CalculatorItem.SEVEN,
+    CalculatorItem.EIGHT,
+    CalculatorItem.NINE,
+    CalculatorItem.DIVIDE
+  ],
+  [
+    CalculatorItem.FOUR,
+    CalculatorItem.FIVE,
+    CalculatorItem.SIX,
+    CalculatorItem.MULTIPLY,
+  ],
+  [
+    CalculatorItem.ONE,
+    CalculatorItem.TWO,
+    CalculatorItem.THREE,
+    CalculatorItem.SUBTRACT,
+  ],
+  [
+    CalculatorItem.PERIOD,
+    CalculatorItem.ZERO,
+    CalculatorItem.BACKSPACE,
+    CalculatorItem.ADD,
+  ],
+];
+
+final operationButtonStyle = TextButton.styleFrom(
+  padding: EdgeInsets.fromLTRB(6.0, 12.0, 6.0, 12.0),
+  primary: Colors.black,
+  backgroundColor: Colors.grey[300],
+);
+
+typedef CalculatorButtonAction = void Function(List<String> stack);
+
+class CalculatorButtonDefinition {
+  IconData icon;
+  CalculatorButtonAction action;
+  String text;
+  ButtonStyle style;
+
+  CalculatorButtonDefinition({this.icon, this.text, this.action, this.style});
+}
+
+final CalculatorButtonAction NOP = (items) => items;
+
+typedef PushLambda = CalculatorButtonAction Function(String Number);
+CalculatorButtonAction pushNumber(String number) {
+  return (List<String> stack) {
+    stack.add(number);
+  };
+}
+
+CalculatorButtonAction pushOperation(String operator) {
+  return (List<String> stack) {
+    final lastItem = stack.removeLast();
+    // Replace opertators
+    if (!operators.contains(lastItem)) {
+      stack.add(lastItem);
+    }
+    stack.add(operator);
+    evaluateExpression(stack);
+  };
+}
+
+final ButtonDefinitions = {
+  CalculatorItem.ZEROZERO: CalculatorButtonDefinition(
+    text: '00',
+    action: (stack) => {
+      stack.addAll(['0', '0'])
+    },
+  ),
+  CalculatorItem.ZERO: CalculatorButtonDefinition(
+    text: '0',
+    action: pushNumber('0'),
+  ),
+  CalculatorItem.ONE: CalculatorButtonDefinition(
+    text: '1',
+    action: pushNumber('1'),
+  ),
+  CalculatorItem.TWO: CalculatorButtonDefinition(
+    text: '2',
+    action: pushNumber('2'),
+  ),
+  CalculatorItem.THREE: CalculatorButtonDefinition(
+    text: '3',
+    action: pushNumber('3'),
+  ),
+  CalculatorItem.FOUR: CalculatorButtonDefinition(
+    text: '4',
+    action: pushNumber('4'),
+  ),
+  CalculatorItem.FIVE: CalculatorButtonDefinition(
+    text: '5',
+    action: pushNumber('5'),
+  ),
+  CalculatorItem.SIX: CalculatorButtonDefinition(
+    text: '6',
+    action: pushNumber('6'),
+  ),
+  CalculatorItem.SEVEN: CalculatorButtonDefinition(
+    text: '7',
+    action: pushNumber('7'),
+  ),
+  CalculatorItem.EIGHT: CalculatorButtonDefinition(
+    text: '8',
+    action: pushNumber('8'),
+  ),
+  CalculatorItem.NINE: CalculatorButtonDefinition(
+    text: '9',
+    action: pushNumber('9'),
+  ),
+  CalculatorItem.PERIOD: CalculatorButtonDefinition(
+    text: '.',
+    action: pushNumber('.'),
+    style: operationButtonStyle,
+  ),
+  CalculatorItem.MULTIPLY: CalculatorButtonDefinition(
+    text: '✖️',
+    action: pushOperation('✖️'),
+    style: operationButtonStyle,
+  ),
+  CalculatorItem.SUBTRACT: CalculatorButtonDefinition(
+    text: '-',
+    action: pushOperation('-'),
+    style: operationButtonStyle,
+  ),
+  CalculatorItem.ADD: CalculatorButtonDefinition(
+    text: '➕',
+    action: pushOperation('➕'),
+    style: operationButtonStyle,
+  ),
+  CalculatorItem.DIVIDE: CalculatorButtonDefinition(
+    text: '➗',
+    action: pushOperation('➗'),
+    style: operationButtonStyle,
+  ),
+  CalculatorItem.BACKSPACE: CalculatorButtonDefinition(
+    text: '⬅️',
+    action: (List<String> stack) {
+      if (stack.isEmpty) {
+        return;
+      }
+      stack.removeLast();
+    },
+    style: operationButtonStyle,
+  ),
+  CalculatorItem.CLEAR: CalculatorButtonDefinition(
+    text: 'AC',
+    action: (List<String> stack) {
+      stack.clear();
+    },
+    style: operationButtonStyle,
+  ),
+  CalculatorItem.EQUAL:
+      CalculatorButtonDefinition(text: '=', action: evaluateExpression),
+  CalculatorItem.BLANK: CalculatorButtonDefinition(text: '', action: NOP),
+};

--- a/lib/components/calculator_keyboard/calculator.dart
+++ b/lib/components/calculator_keyboard/calculator.dart
@@ -1,0 +1,116 @@
+const operators = [
+  '✖️',
+  '*',
+  '-',
+  '➕',
+  '+',
+  '➗',
+  '/',
+];
+
+const numbers = [
+  '0',
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  '.',
+];
+
+double takeNumbers(List<String> stack) {
+  final number = StringBuffer(); // Always add a leasing zero. Prevents
+  // invalid doubles when only a period is entered.
+  while (stack.isNotEmpty) {
+    final maybeNumber = stack.removeLast();
+    final isNumber = numbers.indexOf(maybeNumber);
+    if (isNumber == -1) {
+      stack.add(maybeNumber);
+      break;
+    }
+    number.write(maybeNumber);
+  }
+  if (number.length == 0) {
+    return double.nan;
+  }
+  return double.parse(number.toString(), (value) {
+    stack.addAll(value.split(''));
+    return double.nan;
+  });
+}
+
+typedef BinaryDoubleFunction = double Function(double left, double right);
+
+void evaluateExpression(List<String> stack) {
+  final reversedStack = stack.reversed.toList();
+  final validSymbols =
+      [numbers, operators].expand((element) => element).toList();
+  final output = <double>[];
+
+  final operate = (BinaryDoubleFunction operator) => (String peek) {
+        reversedStack.removeLast();
+        final right = takeNumbers(reversedStack);
+        if (right.isNaN) {
+          reversedStack.add(peek);
+          throw Exception('Failed parsing');
+        }
+        final left = output.removeLast();
+        output.add(operator(left, right));
+      };
+
+  try {
+    OUTER:
+    while (reversedStack.isNotEmpty) {
+      final peek = reversedStack[reversedStack.length - 1];
+      if (!validSymbols.contains(peek)) {
+        throw Exception('Invalid math symbol `${peek}`');
+      }
+
+      switch (peek) {
+        case '✖️':
+          operate((l, r) => l * r)(peek);
+          break;
+        case '*':
+          operate((l, r) => l * r)(peek);
+          break;
+        case '-':
+          operate((l, r) => l - r)(peek);
+          break;
+        case '➕':
+          operate((l, r) => l + r)(peek);
+          break;
+        case '+':
+          operate((l, r) => l + r)(peek);
+          break;
+        case '➗':
+          operate((l, r) => l / r)(peek);
+          break;
+        case '/':
+          operate((l, r) => l / r)(peek);
+          break;
+        default:
+          final number = takeNumbers(reversedStack);
+          if (number.isNaN) {
+            break OUTER;
+          }
+          output.add(number);
+      }
+    }
+  } catch (err) {
+    // Something happened, we are able to just continue though
+    // due to the way the list collapsing happens below.
+  }
+  stack.clear();
+  assert(output.length < 2, 'Invalid output length');
+  if (output.length == 1) {
+    stack.addAll(output.removeLast().truncate().toString().split(''));
+  }
+  stack.addAll(reversedStack.reversed);
+  if (stack.isEmpty) {
+    stack.add('0');
+  }
+}

--- a/lib/components/calculator_keyboard/calculator_button.dart
+++ b/lib/components/calculator_keyboard/calculator_button.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'button_definitions.dart';
+
+typedef CalculatorButtonTapCallback = void Function({String buttonLabel});
+
+class CalculatorButton extends StatelessWidget {
+  final CalculatorItem button;
+  final List<String> stack;
+  final void Function() onPressed;
+
+  CalculatorButton({this.button, this.stack, @required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+        // TODO: Update UI optics on this. Make it snazzy.
+        // TODO: Differentiate the look of operators from the numbers. Is the map
+        // really the best way to do this?
+        child: Container(
+      child: Padding(
+          padding: EdgeInsets.all(3.0),
+          child: ElevatedButton(
+              style: ButtonDefinitions[button].style ??
+                  TextButton.styleFrom(
+                    padding: EdgeInsets.fromLTRB(6.0, 12.0, 6.0, 12.0),
+                    primary: Colors.black,
+                    backgroundColor: Colors.white,
+                  ),
+              onPressed: () {
+                ButtonDefinitions[button].action(stack);
+                onPressed();
+              },
+              child: ButtonDefinitions[button].text == null
+                  ? Icon(
+                      ButtonDefinitions[button].icon,
+                    )
+                  : Text(
+                      ButtonDefinitions[button].text,
+                      style: TextStyle(
+                          fontSize:
+                              32 * MediaQuery.of(context).textScaleFactor),
+                    ))),
+    ));
+  }
+}

--- a/lib/components/calculator_keyboard/calculator_test.dart
+++ b/lib/components/calculator_keyboard/calculator_test.dart
@@ -1,0 +1,80 @@
+import 'package:test/test.dart';
+
+import 'calculator.dart';
+
+void main() {
+  test('takeNumbers generate a double', () async {
+    final numberStack = ['1', '3', '4'].reversed.toList();
+    expect(takeNumbers(numberStack), 134.0);
+  });
+
+  test('takeNumbers takes only first numbers ', () async {
+    final numberStack =
+        ['1', '3', '4', 'x', 'y', '1', '2', '3'].reversed.toList();
+    expect(takeNumbers(numberStack), 134.0);
+  });
+
+  test('takeNumbers handles empty number stack', () async {
+    final numberStack = <String>[];
+    expect(takeNumbers(numberStack).isNaN, true);
+  });
+
+  test('takeNumbers handles stack with no numbers', () async {
+    final numberStack = <String>['x', '2'].reversed.toList();
+    expect(takeNumbers(numberStack).isNaN, true);
+  });
+
+  test('computes multiplication', () async {
+    final numberStack = <String>['2', '✖️', '7'];
+    evaluateExpression(numberStack);
+    expect(numberStack, ['1', '4']);
+  });
+
+  test('handles no leading zero on doubles', () async {
+    final numberStack = <String>['.', '1'];
+    evaluateExpression(numberStack);
+    expect(numberStack, ['0']);
+  });
+
+  test('doesn not blow up on operation w/ no leading zero float', () async {
+    final numberStack = <String>['1', '0', '0', '✖️', '.'];
+    evaluateExpression(numberStack);
+    expect(numberStack, ['1', '0', '0', '✖️', '.']);
+  });
+
+  test('computes sum', () async {
+    final numberStack = <String>['2', '➕', '7'];
+    evaluateExpression(numberStack);
+    expect(numberStack, ['9']);
+  });
+
+  test('computes division', () async {
+    final numberStack = <String>['8', '➗', '2'];
+    evaluateExpression(numberStack);
+    expect(numberStack, ['4']);
+  });
+
+  test('computes subtraction', () async {
+    final numberStack = <String>['8', '-', '2'];
+    evaluateExpression(numberStack);
+    expect(numberStack, ['6']);
+  });
+
+  test('computes complex expression', () async {
+    final numberStack = <String>['8', '-', '2', '➕', '3', '✖️', '4'];
+    evaluateExpression(numberStack);
+    expect(numberStack, ['3', '6']);
+  });
+
+  test('does not choke on invalid expression', () async {
+    final numberStack = <String>['8', '-', '2', '➕', '3', '✖️', '4'];
+    evaluateExpression(numberStack);
+    expect(numberStack, ['3', '6']);
+  });
+
+  test('does not choke on mismatched operators', () async {
+    final numberStack = <String>['8', '-', '2', '➕', '3', '✖️'];
+    evaluateExpression(numberStack);
+    expect(numberStack, ['9', '✖️']);
+  });
+}

--- a/lib/components/calculator_keyboard/keyboard.dart
+++ b/lib/components/calculator_keyboard/keyboard.dart
@@ -1,0 +1,70 @@
+library custom_keyboard;
+
+import 'package:flutter/widgets.dart';
+
+import 'button_definitions.dart';
+import 'calculator_button.dart';
+import 'calculator.dart';
+
+class CalculatorData {
+  int amount;
+  String function;
+  CalculatorData({this.amount, this.function});
+}
+
+class CalculatorKeyboard extends StatelessWidget {
+  final ValueNotifier<CalculatorData> dataNotifier;
+  final List<String> stack = [];
+
+  CalculatorKeyboard(
+      {Key key, String initialValue = '', @required this.dataNotifier})
+      : super(key: key) {
+    stack.addAll(initialValue.split(''));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var amount = 0;
+
+    final updateStack = () {
+      final evaluatedStack = stack.sublist(0);
+      evaluateExpression(evaluatedStack);
+      final takenNumbers = takeNumbers(evaluatedStack.reversed.toList());
+      amount = takenNumbers.truncate();
+
+      // This will be mutated, that's why we need to update the value.
+      dataNotifier.value =
+          CalculatorData(function: stack.join(''), amount: amount);
+    };
+
+    // FIXME: This seems like a terrible way to keep everything in sync on paste.
+    dataNotifier.addListener(() {
+      if (dataNotifier.value.amount == amount) {
+        return;
+      }
+      amount = dataNotifier.value.amount;
+      stack.clear();
+      stack.addAll(dataNotifier.value.function.split(''));
+    });
+
+    return Container(
+        child: Column(
+      children: [
+        Column(
+          children:
+              CalculatorRows.map((List<CalculatorItem> calculatorRowButtons) {
+            return Row(
+              children: calculatorRowButtons.map((CalculatorItem item) {
+                return CalculatorButton(
+                  button: item,
+                  stack: stack,
+                  onPressed: updateStack,
+                );
+              }).toList(),
+            );
+          }).toList(),
+        )
+      ],
+    ));
+  }
+}


### PR DESCRIPTION
Implement a "calculator keyboard" and use it on the send information
data entry screen instead of a standard input box. Additionally, we
also get rid of the text entry field for an address and instead only
allow users to paste into it. There are several other misc things thrown
in with this redesign as well (e.g validation output that disables
the send button).