### PR TITLE
Fix electrum ping response handling

### DIFF
--- a/lib/electrum/rpc.dart
+++ b/lib/electrum/rpc.dart
@@ -167,7 +167,7 @@ class JSONRPCWebsocket {
     final completer = Completer();
 
     outstandingRequests[requestId] = (RPCResponse response) {
-      if (response.result != null) {
+      if (response.error == null) {
         completer.complete(response.result);
       } else {
         completer.completeError(response.error);


### PR DESCRIPTION
Electrum returns a null result, and null error on `ping.` However,
dart completeError bans the return of nulls. Also, a null response
is not an error in this case. Thus, we just want to return null as
a good response except when `error` is explicitly set as a response
by the electrum server.