### PR TITLE
Generate keys on start rather than save them

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -12,6 +12,7 @@ const electrumUrls = [
 const inputSize = 148;
 const outputSize = 34;
 const defaultFeePerByte = 10;
+const defaultNumberOfChildKeys = 20;
 
 // UI constants
 const stdElevation =

--- a/lib/wallet/wallet.dart
+++ b/lib/wallet/wallet.dart
@@ -78,7 +78,6 @@ class Wallet {
 
   /// Fetch UTXOs from electrum then update vault.
   Future<void> updateUtxos(ElectrumClient client) async {
-    var keyIndex = 0;
     for (final keyInfo in keys.keys) {
       final hexScriptHash = HEX.encode(keyInfo.scriptHash);
 
@@ -90,11 +89,10 @@ class Wallet {
         final outpoint =
             Outpoint(unspent.tx_hash, unspent.tx_pos, unspent.value);
 
-        final spendable = Utxo(outpoint, keyIndex);
+        final spendable = Utxo(outpoint, keyInfo.keyIndex);
 
         _vault.addUtxo(spendable);
       }
-      keyIndex += 1;
     }
   }
 


### PR DESCRIPTION
It really does not take very long to generate child keys, assuming that
we have the xpriv key. This commit does not save/restore the keys and
instead generates them on load from the xpriv which is saved. This
allows us to avoid dealing with some state, which is generally always
a good thing.