### PR TITLE
Allow fetching publickey from HDPublicKey

### DIFF
--- a/lib/bitcoincash/hdpublickey.dart
+++ b/lib/bitcoincash/hdpublickey.dart
@@ -80,6 +80,12 @@ class HDPublicKey extends CKDSerializer {
     deserialize(vector);
   }
 
+  /// Constructs a new public key from it's `xpub`-encoded representation
+  BCHPublicKey get publicKey {
+    final point = _domainParams.curve.decodePoint(keyBuffer);
+    return BCHPublicKey.fromPoint(point);
+  }
+
   /// Renders the public key in it's `xpub`-encoded form
   @override
   String toString() {

--- a/lib/bitcoincash/hdpublickey_test.dart
+++ b/lib/bitcoincash/hdpublickey_test.dart
@@ -1,0 +1,80 @@
+import 'package:test/test.dart';
+
+import './hdprivatekey.dart';
+import './bip39/bip39.dart';
+import './networks.dart';
+
+const testSeed =
+    'festival shrimp feel before tackle pyramid immense banner fire wash steel fiscal';
+const firstKey = 'bitcoincash:qrnxtucw0nu882vqhaf6sje4hp9nhh7dgsnamm8e8m';
+
+void main() {
+  test('HDPublicKey generates correct xpub', () async {
+    final seedHex = Mnemonic().toSeedHex(testSeed);
+    final key = HDPrivateKey.fromSeed(seedHex, NetworkType.MAIN);
+
+    expect(key.xpubkey, key.xpubkey);
+    // Derivaiton works properly from both HDPublicKey and HDPrivateKey
+    expect(key.hdPublicKey.deriveChildKey('m/44/145/0').xpubkey,
+        key.deriveChildKey('m/44/145/0').xpubkey);
+  });
+
+  test('HDPublicKey generates correct sub addresses', () async {
+    const testXpriv =
+        'xprv9s21ZrQH143K2Lk5ufDonbZMPWntzAyL8wmP524A4Ex6EAnoep7JeNq6NQbYVv2WmXBjr38xMpmCP9pbNc7K7PgmRfasWE14Jcf4gLYzdxU';
+    final key = HDPrivateKey.fromXpriv(testXpriv);
+    // First account addresses
+    final masterAccountKey = key.deriveChildKey("m/44'/145'/0'");
+    final masterReceiveKey = masterAccountKey.deriveChildNumber(0).hdPublicKey;
+
+    // First 10 keys from account 0
+    const addresses = [
+      'bitcoincash:qrnxtucw0nu882vqhaf6sje4hp9nhh7dgsnamm8e8m',
+      'bitcoincash:qqjr6tclgs6awpvkar4tw8y6276hhhelcc37z4577h',
+      'bitcoincash:qqs7sxex3kmewpwgf2qntfu5g68rg9f7c5lsug7zfv',
+      'bitcoincash:qzswyh6c7qwshawpurgeg7s9ejtdpqgfpyw9unezs6',
+      'bitcoincash:qph7p8a59z0tkgke3hm4n538az99xs5d7yem9ahhuh',
+      'bitcoincash:qqtzzs5zdlzt4gcfvpvagfm3wr9y3uez55kkgs2n9z',
+      'bitcoincash:qz2wp4e4r5tw64wjg5pkd84pj80jeutrhyx2jz8p3r',
+      'bitcoincash:qr2xxm2jqtdzhjrau7k77j4md0yx5spddstvqclrrg',
+      'bitcoincash:qr4vjy45c2ynx373anphps46jghd7kaktyhtspanvq',
+      'bitcoincash:qppeh23mmq2k0jpjtte6069frmkdcgh8zc4wfjmd82'
+    ];
+    addresses.asMap().forEach((keyNumber, address) {
+      expect(
+          masterReceiveKey
+              .deriveChildNumber(keyNumber)
+              .publicKey
+              .toAddress()
+              .toCashAddress(),
+          address,
+          reason:
+              'Keynumber ${keyNumber} failed to check against test vectors');
+    });
+
+    final masterChangeKey = masterAccountKey.deriveChildNumber(1).hdPublicKey;
+    const changeAddresses = [
+      'bitcoincash:qq38hnvjfq9ftkwwtfukha8mu2wg026ldqn8wv9u6n',
+      'bitcoincash:qpt23tmsyrkrgjlgp2agewhf77mfchj2h555sqhfz0',
+      'bitcoincash:qz8qe5p5zjfkz63r9yyydw5ewwps74rg454clr9n8x',
+      'bitcoincash:qr0al93f8xjx0egfx6wekp0wc6egvsvz6y5frq9hmx',
+      'bitcoincash:qz4ra979la4qlvuqemqsmeunkuxcw785hqrmrv2mlm',
+      'bitcoincash:qzz2j3v8jnws9jjvfv6evapder8x76w355ssf4r9tj',
+      'bitcoincash:qqq357wsxuq2f6mq6vswqc4nxsnymtq0yg5pdcdqd3',
+      'bitcoincash:qrj7ktwvcn0ahjps7tf0kdnwnlg8ue02aupph7pefa',
+      'bitcoincash:qp690r5ws6xn6wl03jsa2gj8le9zs4r8qcmrpgn298',
+      'bitcoincash:qpglyxgjazet9s7h2aafg48sfk52ln7gruequv0lga',
+    ];
+    changeAddresses.asMap().forEach((keyNumber, address) {
+      expect(
+          masterChangeKey
+              .deriveChildNumber(keyNumber)
+              .publicKey
+              .toAddress()
+              .toCashAddress(),
+          address,
+          reason:
+              'Keynumber ${keyNumber} failed to check against test vectors');
+    });
+  });
+}

--- a/lib/bitcoincash/privatekey.dart
+++ b/lib/bitcoincash/privatekey.dart
@@ -223,7 +223,7 @@ class BCHPrivateKey {
   /// Convenience method that jumps through the hoops of generating and [Address] from this
   /// Private Key's corresponding [BCHPublicKey].
   Address toAddress({NetworkType networkType = NetworkType.MAIN}) {
-    return _BCHPublicKey.toAddress(networkType ?? _networkType);
+    return _BCHPublicKey.toAddress(networkType: networkType ?? _networkType);
   }
 
   Uint8List _seed() {

--- a/lib/bitcoincash/publickey.dart
+++ b/lib/bitcoincash/publickey.dart
@@ -49,6 +49,22 @@ class BCHPublicKey {
     _point = finalPoint;
   }
 
+  /// Creates a  public key from it's corresponding ECDSA private key bigint.
+  ///
+  /// NOTE: public key *Q* is computed as `Q = d * G` where *d* is the private key
+  /// and *G* is the elliptic curve Generator.
+  ///
+  /// [privkey] - The private key who's *d*-value we will use.
+  BCHPublicKey.fromPoint(ECPoint pubkeyPoint) {
+    // create a  point taking into account compression request/indicator of parent private key
+    var finalPoint = _domainParams.curve.createPoint(
+        pubkeyPoint.x.toBigInteger(), pubkeyPoint.y.toBigInteger(), true);
+
+    _checkIfOnCurve(finalPoint); // a bit paranoid
+
+    _point = finalPoint;
+  }
+
   /// Creates a public key instance from the ECDSA public key's `x-coordinate`
   ///
   /// ECDSA has some cool properties. Because we are dealing with an elliptic curve in a plane,
@@ -178,14 +194,14 @@ class BCHPublicKey {
 
   /// Convenience method that constructs an [Address] instance from this
   /// public key.
-  Address toAddress(NetworkType nat) {
+  Address toAddress({NetworkType networkType = NetworkType.MAIN}) {
     // generate compressed addresses by default
     List<int> buffer = _point.getEncoded(_point.isCompressed);
 
     if (_point.isCompressed) {
-      return Address.fromCompressedPubKey(buffer, nat);
+      return Address.fromCompressedPubKey(buffer, networkType);
     } else {
-      return Address.fromHex(HEX.encode(buffer), nat);
+      return Address.fromHex(HEX.encode(buffer), networkType);
     }
   }
 


### PR DESCRIPTION
This commit allows actually getting the BCHPublicKey from the
HDPublicKey -- which was previously not possible. This enables using
XPUBS to generate new addresses. Additionally, we add a few tests to
make sure that it works.