### PR TITLE
Clarify names of BigInt encoding/decoding functions for future ref.

### DIFF
--- a/lib/bitcoincash/encoding/utils.dart
+++ b/lib/bitcoincash/encoding/utils.dart
@@ -202,7 +202,7 @@ int getBufferOffset(int count) {
 }
 
 /// Decode a BigInt from bytes in big-endian encoding.
-BigInt decodeBigInt(List<int> bytes) {
+BigInt decodeUInt256(List<int> bytes) {
   var result = BigInt.from(0);
 
   for (var i = 0; i < bytes.length; i++) {
@@ -215,7 +215,7 @@ BigInt decodeBigInt(List<int> bytes) {
 var _byteMask = BigInt.from(0xff);
 
 /// Encode a BigInt into bytes using big-endian encoding.
-Uint8List encodeBigInt(BigInt number) {
+Uint8List encodeUInt256(BigInt number) {
   var size = (number.bitLength + 7) >> 3;
 
   var result = Uint8List(size);
@@ -293,7 +293,7 @@ BigInt fromSM(Uint8List buf, {Endian endian = Endian.big}) {
   BigInt ret;
   var localBuffer = buf.toList();
   if (localBuffer.isEmpty) {
-    return decodeBigInt([0]);
+    return decodeUInt256([0]);
   }
 
   if (endian == Endian.little) {
@@ -302,10 +302,10 @@ BigInt fromSM(Uint8List buf, {Endian endian = Endian.big}) {
 
   if (localBuffer[0] & 0x80 != 0) {
     localBuffer[0] = localBuffer[0] & 0x7f;
-    ret = decodeBigInt(localBuffer);
+    ret = decodeUInt256(localBuffer);
     ret = (-ret);
   } else {
-    ret = decodeBigInt(localBuffer);
+    ret = decodeUInt256(localBuffer);
   }
 
   return ret;

--- a/lib/bitcoincash/hdpublickey.dart
+++ b/lib/bitcoincash/hdpublickey.dart
@@ -140,11 +140,12 @@ class HDPublicKey extends CKDSerializer {
     var I =
         HDUtils.hmacSha512WithKey(chainCode, Uint8List.fromList(dataConcat));
 
+// Ensure value is interpreted as positive by padding.
     var lhs = I.sublist(0, 32);
     var childChainCode = I.sublist(32, 64);
 
     var privateKey =
-        BCHPrivateKey.fromBigInt(decodeBigInt(lhs), networkType: networkType);
+        BCHPrivateKey.fromBigInt(decodeUInt256(lhs), networkType: networkType);
     var derivedPoint = privateKey.publicKey.point + publicKeyPoint;
 
     // TODO: Validate that the point is on the curve !

--- a/lib/bitcoincash/publickey.dart
+++ b/lib/bitcoincash/publickey.dart
@@ -30,7 +30,7 @@ class BCHPublicKey {
   ///
   /// [privkey] - The private key who's *d*-value we will use.
   BCHPublicKey.fromPrivateKey(BCHPrivateKey privkey) {
-    var decodedPrivKey = encodeBigInt(privkey.privateKey);
+    var decodedPrivKey = encodeUInt256(privkey.privateKey);
     var hexPrivKey = HEX.encode(decodedPrivKey);
 
     var actualKey = hexPrivKey;

--- a/lib/bitcoincash/signature.dart
+++ b/lib/bitcoincash/signature.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 import 'package:pointycastle/api.dart';
 import 'package:pointycastle/digests/sha256.dart';
 import 'package:pointycastle/export.dart';
-import 'package:pointycastle/src/utils.dart' as utils;
 import 'package:pointycastle/macs/hmac.dart';
 import 'package:pointycastle/signers/ecdsa_signer.dart';
 import 'package:pointycastle/pointycastle.dart';
@@ -119,8 +118,8 @@ class BCHSignature {
 
     _compressed = compressed;
     _i = i;
-    _r = utils.decodeBigInt(b2);
-    _s = utils.decodeBigInt(b3);
+    _r = asn1.ASN1Utils.decodeBigInt(b2);
+    _s = asn1.ASN1Utils.decodeBigInt(b3);
 
     _rHex = _r.toRadixString(16);
     _sHex = _s.toRadixString(16);
@@ -147,8 +146,8 @@ class BCHSignature {
     }
 
     var b1 = [val];
-    var b2 = utils.encodeBigInt(_r);
-    var b3 = utils.encodeBigInt(_s);
+    var b2 = asn1.ASN1Utils.encodeBigInt(_r);
+    var b3 = asn1.ASN1Utils.encodeBigInt(_s);
     return b1 + b2 + b3;
   }
 
@@ -383,7 +382,7 @@ class BCHSignature {
       throw SignatureException('i must be equal to 0, 1, 2, or 3');
     }
 
-    var e = utils.decodeBigInt(hashBuffer);
+    var e = asn1.ASN1Utils.decodeBigInt(hashBuffer);
     var r = this.r;
     var s = this.s;
 


### PR DESCRIPTION
As per title. Also, ensure padding is added when encoding so that the
`keybuffer` value in hdprivatekey isn't so sensitive to being padded
or not. In some cases, it was not being added upfront and this caused
various bugs.