### PR TITLE
Use pool package for loading multiple unspent utxos at once

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -430,7 +430,7 @@ packages:
     source: hosted
     version: "2.0.0"
   pool:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: pool
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   slider_button: 0.6.0
   provider: ^4.0.0
   flutter_secure_storage: 3.3.5
+  pool: ^1.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Currently, we only list unspent utxos for one address at a time. We can,
instead list a few at a time. The pool package for dart enables us to
limit to concurrency so we don't make the Electrum Server Gods angry,
while still reducing the total latency to get all our UTXOs.