### PR TITLE
Kludge together back button handling in PageViews

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -53,12 +53,28 @@ class _MainPageState extends State<MainPage> {
     if (viewModel.initialized) {
       viewModel.writeToDisk();
     }
+    final ScopePopper = (widget) => WillPopScope(
+        onWillPop: () async {
+          print(pagerController.page.toString());
+          if (pagerController.page == 1.0) {
+            return true;
+          }
+          return pagerController
+              .animateToPage(1,
+                  duration: Duration(milliseconds: 400),
+                  curve: Curves.easeInOut)
+              .then((_) async {
+            return false;
+          });
+        },
+        child: widget);
+
     final pageView = PageView(
       controller: pagerController,
       children: [
-        SettingsTab(),
-        SendTab(controller: pagerController),
-        ReceiveTab(),
+        ScopePopper(SettingsTab()),
+        ScopePopper(SendTab(controller: pagerController)),
+        ScopePopper(ReceiveTab()),
       ],
     );
 


### PR DESCRIPTION
It seems as though the Flutter Android Navigation API does not support
PageViews natively. There are no clear solutions for how to handle this
online. Instead, I am using the WillPopScope override control, to cause
transitions between pages were applicable. There is
probably a better way to do this.