### PR TITLE
Fix another issue with key encodings

### DIFF
--- a/lib/bitcoincash/encoding/ckdserializer.dart
+++ b/lib/bitcoincash/encoding/ckdserializer.dart
@@ -8,6 +8,7 @@ import '../networks.dart';
 import 'base58check.dart' as bs58check;
 import 'utils.dart' as utils;
 
+// TODO: This entire class should be using Uint8List entirely.
 abstract class CKDSerializer {
   static final List<int> MAINNET_PUBLIC = HEX.decode('0488B21E');
   static final List<int> MAINNET_PRIVATE = HEX.decode('0488ADE4');
@@ -97,12 +98,16 @@ abstract class CKDSerializer {
   ///
   /// `bytes` - Hexadecimal version of key encoded as a byte buffer
   set keyBuffer(List<int> bytes) {
-    _keyHex = bytes;
+    var paddedKey = List<int>.filled(33, 0);
+    paddedKey.setRange(33 - bytes.length, 33, bytes);
+    _keyHex = paddedKey;
   }
 
   /// Retrieves the key as a byte buffer
   ///
   List<int> get keyBuffer {
+    // TODO: Why does this need to be converted to a Uin8list and back?
+    // Simply duplicating the lists broke lots of the code.
     return Uint8List.fromList(_keyHex).toList();
   }
 

--- a/lib/bitcoincash/hdprivatekey.dart
+++ b/lib/bitcoincash/hdprivatekey.dart
@@ -158,8 +158,7 @@ class HDPrivateKey extends CKDSerializer {
     var seriList = Uint8List(4);
     seriList.buffer.asByteData(0, 4).setUint32(0, cn.i);
 
-    var paddedKey = Uint8List(33);
-    paddedKey.setRange(33 - keyBuffer.length, 33, keyBuffer);
+    var paddedKey = Uint8List.fromList(keyBuffer);
 
     var dataConcat = cn.isHardened()
         ? paddedKey + seriList

--- a/lib/bitcoincash/hdprivatekey_test.dart
+++ b/lib/bitcoincash/hdprivatekey_test.dart
@@ -98,8 +98,11 @@ void main() {
     final masterAccountKey = key.deriveChildKey("m/44'/145'/0'");
     final masterReceiveKey = masterAccountKey.deriveChildNumber(1);
 
-    for (var i = 0; i < 100; i++) {
+    for (var i = 0; i < 1000; i++) {
       expect(() => masterReceiveKey.deriveChildNumber(i), returnsNormally,
+          reason: 'Key ${i} failed to generate');
+      expect(
+          () => masterReceiveKey.deriveChildNumber(i).xprivkey, returnsNormally,
           reason: 'Key ${i} failed to generate');
     }
   });


### PR DESCRIPTION
In some cases, an xprivkey cannot be generated because the normal
serialization is less than 33 bytes. This means the CKDSerializer class
blows up, because it currently makes bad assumptions. The quick fix is
to move padding to 33 bytes into the CKD Serializer class. However, upon
further investigation, this class needs to be refactored itself.