### PR TITLE
Make balance widget show errors with RPC connections

### DIFF
--- a/lib/electrum/rpc.dart
+++ b/lib/electrum/rpc.dart
@@ -118,7 +118,7 @@ class JSONRPCWebsocket {
     final key = base64.encode(List<int>.generate(8, (_) => r.nextInt(255)));
 
     final client = HttpClient();
-    client.connectionTimeout = const Duration(milliseconds: 1000);
+    client.connectionTimeout = const Duration(milliseconds: 10);
     client.badCertificateCallback =
         (X509Certificate cert, String host, int port) => true;
     final request = await client.getUrl(address);

--- a/lib/tabs/send/send.dart
+++ b/lib/tabs/send/send.dart
@@ -108,20 +108,30 @@ class _SendTabState extends State<SendTab> {
               color: Colors.grey[400].withOpacity(0.6),
               child: Row(
                 children: [
+                  // TODO: Dedupe this widget.
                   ValueListenableBuilder(
                       valueListenable: balanceNotifier,
                       builder: (context, balance, child) {
-                        if (balance == null) {
+                        if (balance.error != null) {
+                          return Text(
+                            balance.error.message,
+                            style: TextStyle(
+                                color: Colors.red,
+                                fontWeight: FontWeight.bold,
+                                fontSize: 13),
+                          );
+                        }
+                        if (balance.balance == null) {
                           return Text(
                             'Loading...',
                             style: TextStyle(
-                                color: Colors.red.withOpacity(.8),
+                                color: Colors.grey,
                                 fontWeight: FontWeight.bold,
                                 fontSize: 13),
                           );
                         }
                         return Text.rich(TextSpan(
-                          text: '${balance}',
+                          text: '${balance.balance}',
                           style: TextStyle(
                             color: Colors.white,
                             fontWeight: FontWeight.bold,

--- a/lib/tabs/send/send_info.dart
+++ b/lib/tabs/send/send_info.dart
@@ -130,8 +130,10 @@ class SendInfo extends StatelessWidget {
             children: [
               Expanded(child:
                   Consumer<SendModel>(builder: (context, viewModel, child) {
-                final errors = canSend(viewModel.sendAmount ?? 0,
-                    viewModel.sendToAddress, walletModel.balance.value ?? 0);
+                final errors = canSend(
+                    viewModel.sendAmount ?? 0,
+                    viewModel.sendToAddress,
+                    walletModel.balance.value.balance ?? 0);
                 return Column(
                     mainAxisAlignment: MainAxisAlignment.end,
                     crossAxisAlignment: CrossAxisAlignment.end,
@@ -176,8 +178,10 @@ class SendInfo extends StatelessWidget {
                                     keyboardNotifier.value.function ?? '')))
               ]),
               Consumer<SendModel>(builder: (context, viewModel, child) {
-                final errors = canSend(viewModel.sendAmount ?? 0,
-                    viewModel.sendToAddress, walletModel.balance.value ?? 0);
+                final errors = canSend(
+                    viewModel.sendAmount ?? 0,
+                    viewModel.sendToAddress,
+                    walletModel.balance.value.balance ?? 0);
                 return Row(children: [
                   Expanded(
                       child: ElevatedButton(
@@ -245,7 +249,7 @@ class AddressDisplay extends StatelessWidget {
 }
 
 class BalanceDisplay extends StatelessWidget {
-  final ValueNotifier<int> balanceNotifier;
+  final ValueNotifier<WalletBalance> balanceNotifier;
   BalanceDisplay({@required this.balanceNotifier});
 
   @override
@@ -261,20 +265,30 @@ class BalanceDisplay extends StatelessWidget {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
+              // TODO: Dedupe this widget.
               ValueListenableBuilder(
                   valueListenable: balanceNotifier,
                   builder: (context, balance, child) {
-                    if (balance == null) {
+                    if (balance.error != null) {
+                      return Text(
+                        balance.error.message,
+                        style: TextStyle(
+                            color: Colors.red,
+                            fontWeight: FontWeight.bold,
+                            fontSize: 13),
+                      );
+                    }
+                    if (balance.balance == null) {
                       return Text(
                         'Loading...',
                         style: TextStyle(
-                            color: Colors.red.withOpacity(.8),
+                            color: Colors.grey,
                             fontWeight: FontWeight.bold,
                             fontSize: 13),
                       );
                     }
                     return Text.rich(TextSpan(
-                      text: 'Balance: ${balance}',
+                      text: '${balance.balance}',
                       style: TextStyle(
                         color: Colors.black,
                         fontWeight: FontWeight.bold,

--- a/lib/tabs/settings.dart
+++ b/lib/tabs/settings.dart
@@ -26,20 +26,30 @@ class SettingsTab extends StatelessWidget {
           ),
           Padding(
             padding: const EdgeInsets.all(16.0),
+            // TODO: Dedupe this widget.
             child: ValueListenableBuilder(
                 valueListenable: balanceNotifier,
                 builder: (context, balance, child) {
-                  if (balance == null) {
+                  if (balance.error != null) {
+                    return Text(
+                      balance.error.message,
+                      style: TextStyle(
+                          color: Colors.red,
+                          fontWeight: FontWeight.bold,
+                          fontSize: 13),
+                    );
+                  }
+                  if (balance.balance == null) {
                     return Text(
                       'Loading...',
                       style: TextStyle(
-                          color: Colors.red.withOpacity(.8),
+                          color: Colors.grey,
                           fontWeight: FontWeight.bold,
                           fontSize: 13),
                     );
                   }
                   return Text.rich(TextSpan(
-                    text: '${balance} sats',
+                    text: '${balance.balance}',
                     style: TextStyle(
                       color: Colors.black,
                       fontWeight: FontWeight.bold,

--- a/lib/viewmodel.dart
+++ b/lib/viewmodel.dart
@@ -31,13 +31,13 @@ class WalletModel with ChangeNotifier {
   // Internally use a ValueNotifier here, as we don't want the entire wallet
   // to refresh when this field is updated.
   // We should probably introduce a secondary model of some sort.
-  final ValueNotifier<int> balance;
+  final ValueNotifier<WalletBalance> balance;
   final FlutterSecureStorage _storage;
 
   // TODO: Storage should be injected
   WalletModel()
       : _storage = FlutterSecureStorage(),
-        balance = ValueNotifier<int>(null) {
+        balance = ValueNotifier<WalletBalance>(WalletBalance()) {
     initializeModel(); // Run in background.
   }
 


### PR DESCRIPTION
Instead of simplify updating the balance on changes to the balance,
we also update it on error conditions during initialization. This should
help figure out what is going on with some people never passing the
`Loading...` stage.

Pertains to #135