### PR TITLE
Fix electrum client connection retries, and remove init retries

### DIFF
--- a/lib/electrum/client.dart
+++ b/lib/electrum/client.dart
@@ -77,7 +77,7 @@ class ElectrumFactory {
   ConnectHandler onConnected;
 
   /// Builds client if non-existent and attempts to connect before resolving.
-  Future<ElectrumClient> getInstance() async {
+  Future<ElectrumClient> getInstance({int retry = 2}) async {
     try {
       if (_client == null) {
         _client = ElectrumClient(disconnectHandler: (error) {
@@ -91,7 +91,11 @@ class ElectrumFactory {
       }
     } catch (err) {
       print(err);
-      return await getInstance();
+      _client = null;
+      if (retry == 0) {
+        rethrow;
+      }
+      return await getInstance(retry: retry - 1);
     }
     return _client;
   }

--- a/lib/electrum/rpc.dart
+++ b/lib/electrum/rpc.dart
@@ -125,8 +125,8 @@ class JSONRPCWebsocket {
     request.headers.add('Connection', 'upgrade');
     request.headers.add('Upgrade', 'websocket');
     request.headers
-        .add('sec-websocket-version', '13'); // insert the correct version here
-    request.headers.add('sec-websocket-key', key);
+        .add('Sec-WebSocket-Version', '13'); // insert the correct version here
+    request.headers.add('Sec-WebSocket-Key', key);
 
     final response = await request.close();
     // todo check the status code, key etc

--- a/lib/wallet/wallet.dart
+++ b/lib/wallet/wallet.dart
@@ -139,19 +139,16 @@ class Wallet {
     _balance = totalBalance;
   }
 
-  void initialize({int retry = 2}) async {
-    final client = await electrumFactory.getInstance();
-
+  void initialize() async {
     // Wipe out the vault before refreshing UTXOs
     try {
+      final client = await electrumFactory.getInstance();
+
       await updateUtxos(client);
     } catch (err) {
       print(err);
-      if (retry == 0) {
-        updateBalance(WalletBalance(balance: null, error: err));
-        return;
-      }
-      return initialize(retry: retry - 1);
+      updateBalance(WalletBalance(balance: null, error: err));
+      return;
     }
     refreshBalanceLocal();
   }


### PR DESCRIPTION
The retries added to initialization were there due to mistakenly
thinking rpcSocket was being unset by dispose. However, it was due to
faulty retry logic in getInstance. This commit fixes it by ensuring
that _client is reset to nil before retrying. This prevents double
retries. (e.g. 3*3 retries) from both functions.  Also, update the
casing of the WebSocket header fields, though this should not
matter at all.