### PR TITLE
Fix display of balance during wallet refresh

### DIFF
--- a/lib/tabs/send/send.dart
+++ b/lib/tabs/send/send.dart
@@ -112,7 +112,7 @@ class _SendTabState extends State<SendTab> {
                   ValueListenableBuilder(
                       valueListenable: balanceNotifier,
                       builder: (context, balance, child) {
-                        if (balance.error != null) {
+                        if (balance != null && balance.error != null) {
                           return Text(
                             balance.error.message,
                             style: TextStyle(
@@ -121,7 +121,7 @@ class _SendTabState extends State<SendTab> {
                                 fontSize: 13),
                           );
                         }
-                        if (balance.balance == null) {
+                        if (balance == null || balance.balance == null) {
                           return Text(
                             'Loading...',
                             style: TextStyle(

--- a/lib/tabs/send/send_info.dart
+++ b/lib/tabs/send/send_info.dart
@@ -269,7 +269,7 @@ class BalanceDisplay extends StatelessWidget {
               ValueListenableBuilder(
                   valueListenable: balanceNotifier,
                   builder: (context, balance, child) {
-                    if (balance.error != null) {
+                    if (balance != null && balance.error != null) {
                       return Text(
                         balance.error.message,
                         style: TextStyle(
@@ -278,7 +278,7 @@ class BalanceDisplay extends StatelessWidget {
                             fontSize: 13),
                       );
                     }
-                    if (balance.balance == null) {
+                    if (balance == null || balance.balance == null) {
                       return Text(
                         'Loading...',
                         style: TextStyle(

--- a/lib/tabs/settings.dart
+++ b/lib/tabs/settings.dart
@@ -30,7 +30,7 @@ class SettingsTab extends StatelessWidget {
             child: ValueListenableBuilder(
                 valueListenable: balanceNotifier,
                 builder: (context, balance, child) {
-                  if (balance.error != null) {
+                  if (balance != null && balance.error != null) {
                     return Text(
                       balance.error.message,
                       style: TextStyle(
@@ -39,7 +39,7 @@ class SettingsTab extends StatelessWidget {
                           fontSize: 13),
                     );
                   }
-                  if (balance.balance == null) {
+                  if (balance == null || balance.balance == null) {
                     return Text(
                       'Loading...',
                       style: TextStyle(


### PR DESCRIPTION
Kludge fix for balance crashing the wallet during wallet refreshes.
This component really should be factored out into a different stateless
component.