### PR TITLE
Fix send status message that was broken by switching to navigator widget

### DIFF
--- a/lib/tabs/send/send_info.dart
+++ b/lib/tabs/send/send_info.dart
@@ -75,9 +75,8 @@ class SendInfo extends StatelessWidget {
       walletModel.wallet
           .sendTransaction(Address(address), BigInt.from(amount))
           .then((transaction) => showReceipt(context, transaction))
-          .catchError((error) => showError(context, error.toString()));
-
-      Navigator.pop(context);
+          .catchError((error) => showError(context, error.toString()))
+          .then((_) => Navigator.pop(context));
     }
 
     final pasteAddress = () async {


### PR DESCRIPTION
Due to Navigator.pop, the send_info screen gets disposed, and then the
dialog cannot be shown within that build context. This commit fixes that
by defering the `pop` until after the transaction is finished sending.