### PR TITLE
Fix amount processing on the receive screen from the pay-to URI

### DIFF
--- a/lib/tabs/send/send_info.dart
+++ b/lib/tabs/send/send_info.dart
@@ -95,8 +95,12 @@ class SendInfo extends StatelessWidget {
         if (amount.isNaN) {
           return;
         }
+        if (amount.truncateToDouble() != amount) {
+          sendModel.sendAmount = (amount * 100000000).truncate();
+        } else {
+          sendModel.sendAmount = amount.truncate();
+        }
 
-        sendModel.sendAmount = (amount * 100000000).truncate();
         keyboardNotifier.value = CalculatorData(
             amount: sendModel.sendAmount,
             function: sendModel.sendAmount == 0


### PR DESCRIPTION
Currently, there is a mismatch between the expectations on the send
and receive screen with relation to the amount in the URI. This commit
attempts to estimate if the amount when scanning a URI is in BCHA, or
in sats. It converts BCHA to sats for the purpose of sending.