### PR TITLE
Add support for ecash prefix going forward

### DIFF
--- a/lib/bitcoincash/address.dart
+++ b/lib/bitcoincash/address.dart
@@ -43,10 +43,15 @@ class Address {
   ///
   Address(String address) {
     try {
-      _fromCashAddress(address);
+      _fromCashAddress(address, 'ecash');
       return;
     } catch (e) {
-      _fromBase58(address);
+      try {
+        _fromCashAddress(address, 'bitcoincash');
+        return;
+      } catch (e) {
+        _fromBase58(address);
+      }
     }
   }
 
@@ -149,11 +154,12 @@ class Address {
 
   /// Serialise this address object to a cashaddr encoded string
   ///
-  String toCashAddress() {
+  String toCashAddress({prefix = 'bitcoincash'}) {
     return cash_address.Encode(cash_address.RawCashAddress(
         addressBytes: HEX.decode(_publicKeyHash),
         networkType: networkType,
-        addressType: addressType));
+        addressType: addressType,
+        prefix: prefix));
   }
 
   /// Serialise this address object to a base58-encoded string.
@@ -208,8 +214,8 @@ class Address {
         HEX.encode(stripVersion.map((elem) => elem.toUnsigned(8)).toList());
   }
 
-  void _fromCashAddress(String address) {
-    final rawAddressData = cash_address.Decode(address);
+  void _fromCashAddress(String address, String prefix) {
+    final rawAddressData = cash_address.Decode(address, prefix);
     _networkType = rawAddressData.networkType;
     _addressType = rawAddressData.addressType;
     _publicKeyHash = HEX.encode(rawAddressData.addressBytes);

--- a/lib/bitcoincash/cashaddress.dart
+++ b/lib/bitcoincash/cashaddress.dart
@@ -3,14 +3,14 @@ import 'exceptions.dart';
 import 'encoding/base32.dart';
 import 'encoding/convertbits.dart';
 
+const defaultPrefix = 'bitcoincash';
+
 class RawCashAddress {
   AddressType addressType;
   NetworkType networkType;
   List<int> addressBytes;
 
-  String get prefix {
-    return 'bitcoincash';
-  }
+  String prefix;
 
   int get version {
     switch (addressType) {
@@ -23,7 +23,11 @@ class RawCashAddress {
     }
   }
 
-  RawCashAddress({this.addressType, this.networkType, this.addressBytes});
+  RawCashAddress(
+      {this.addressType,
+      this.networkType,
+      this.addressBytes,
+      this.prefix = defaultPrefix});
 }
 
 const globalDefaultPrefix = 'bitcoincash';
@@ -125,6 +129,10 @@ NetworkType getNetworkTypeFromPrefix(String prefix) {
   switch (prefix) {
     case 'bitcoincash':
       return NetworkType.MAIN;
+    case 'ecash':
+      return NetworkType.MAIN;
+    case 'tecash':
+      return NetworkType.TEST;
     case 'bchtest':
       return NetworkType.TEST;
     case 'bchreg':


### PR DESCRIPTION
By default, we still display the `bitcoincash` prefix. However, we will
support scanning `ecash` addresses.