### PR TITLE
Changed minus sign to heavy minus emoji in Calculator Keyboard

### DIFF
--- a/lib/components/calculator_keyboard/button_definitions.dart
+++ b/lib/components/calculator_keyboard/button_definitions.dart
@@ -159,8 +159,8 @@ final ButtonDefinitions = {
     style: operationButtonStyle,
   ),
   CalculatorItem.SUBTRACT: CalculatorButtonDefinition(
-    text: '-',
-    action: pushOperation('-'),
+    text: '➖',
+    action: pushOperation('➖'),
     style: operationButtonStyle,
   ),
   CalculatorItem.ADD: CalculatorButtonDefinition(


### PR DESCRIPTION
In response to user requests, this updates the style of the minus sign to be on par with that of the other math operations on the keyboard. 

![Screen Shot 2021-01-10 at 9 08 50 PM](https://user-images.githubusercontent.com/26187282/104149083-c83d0800-5389-11eb-8a70-0daee1a4d208.png)
