### PR TITLE
Fix remote balance refresh function in wallet.dart to update ValueNotifier when done.

### DIFF
--- a/lib/wallet/wallet.dart
+++ b/lib/wallet/wallet.dart
@@ -135,6 +135,8 @@ class Wallet {
         .map((response) => response.confirmed + response.unconfirmed)
         .fold(0, (p, c) => p + c);
     _balance = totalBalance;
+
+    updateBalance(WalletBalance(balance: _balance));
   }
 
   void initialize() async {


### PR DESCRIPTION
We seem to have left out updateBalance at the end, in the refreshBalanceRemote() function in the wallet.dart library, unlike for the preceding refreshBalanceLocal() function. 

Although there are no issues reported currently and the initialize() function calls refreshBalanceLocal(), so that the change is not necessary or even superfluous, hopeful that this makes the library more robust in general, and might avoid errors in the future if/when the function is used. i.e., If _balance is being overwritten, we don't want _balance being different from what the user is seeing. 

One alternative to accepting this PR is to reject the change but also remove overwriting _balance, and assert that the two calculated balances from refreshBalanceLocal and refreshBalanceRemote are equal before deciding what to do. 