### PR TITLE
Add support for XAddresses in the Lotus library

### DIFF
--- a/lib/lotus/address_test.dart
+++ b/lib/lotus/address_test.dart
@@ -36,4 +36,18 @@ void main() {
     var address = Address(legacy);
     expect(address.toCashAddress(), cashaddr);
   });
+
+  test('can decode from lotus and encode to cashaddress', () async {
+    final xAddress = 'lotusT16PSJHU42xeYK54uebr811ZAdJ5LhsJRw92YAFVax';
+    final cashaddr = 'bchtest:qq9e0r875ed2zmd6qe0kgsjxwjnadzrl9sukcatjha';
+    var address = Address(xAddress);
+    expect(address.toCashAddress(), cashaddr);
+  });
+
+  test('can decode from cashaddress and encode to xaddress', () async {
+    final xAddress = 'lotusT16PSJHU42xeYK54uebr811ZAdJ5LhsJRw92YAFVax';
+    final cashaddr = 'bchtest:qq9e0r875ed2zmd6qe0kgsjxwjnadzrl9sukcatjha';
+    var address = Address(cashaddr);
+    expect(address.toXAddress(), xAddress);
+  });
 }

--- a/lib/lotus/cashaddress.dart
+++ b/lib/lotus/cashaddress.dart
@@ -142,6 +142,21 @@ NetworkType getNetworkTypeFromPrefix(String prefix) {
   }
 }
 
+/// getPrefixFromNetworkType converts a Network Type to a
+/// cashaddress prefix for generating accesses appropriately.
+String getPrefixFromNetworkType(NetworkType type) {
+  switch (type) {
+    case NetworkType.MAIN:
+      return 'bitcoincash';
+    case NetworkType.TEST:
+      return 'bchtest';
+    case NetworkType.REGTEST:
+      return 'bchreg';
+    default:
+      return 'bitcoincash';
+  }
+}
+
 /// getAddressTypeFromByte converts a address type into the
 /// appropriate [AddressType] for internal representations.
 AddressType getAddressTypeFromByte(int addressType) {

--- a/lib/lotus/xaddress.dart
+++ b/lib/lotus/xaddress.dart
@@ -1,0 +1,125 @@
+import 'dart:typed_data';
+import 'package:collection/collection.dart';
+
+import 'exceptions.dart';
+import 'networks.dart';
+import 'encoding/base58check.dart' as base58;
+import 'encoding/utils.dart';
+
+const TOKEN_NAME = 'lotus';
+const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+enum XAddressType {
+  ScriptPubKey,
+}
+
+class XAddress {
+  XAddressType type;
+  NetworkType network;
+  List<int> payload;
+
+  String prefix;
+
+  XAddress(
+      {this.type = XAddressType.ScriptPubKey,
+      this.network,
+      this.payload,
+      this.prefix = TOKEN_NAME});
+
+  XAddress.Decode(String address) {
+    final splitLocation = address.indexOf(RegExp(r'[A-Z_]'));
+    prefix = address.substring(0, splitLocation);
+    network =
+        _GetNetworkType(address.substring(splitLocation, splitLocation + 1));
+    final decodedBytes = base58.decode(address.substring(splitLocation + 1));
+    type = _GetAddressType(decodedBytes.first);
+    payload = decodedBytes.sublist(1, decodedBytes.length - 4);
+    final checksum = _CreateChecksum(this);
+    final decodedChecksum = decodedBytes.sublist(decodedBytes.length - 4);
+    if (!ListEquality().equals(decodedChecksum, checksum)) {
+      throw AddressFormatException('Invalid checksum');
+    }
+  }
+
+  int get typeByte {
+    switch (type) {
+      case XAddressType.ScriptPubKey:
+        return 0;
+      default:
+        throw AddressFormatException('Unknown address type');
+    }
+    return 0;
+  }
+
+  String get networkByte {
+    switch (network) {
+      case NetworkType.MAIN:
+        return '_';
+      case NetworkType.TEST:
+        return 'T';
+      case NetworkType.REGTEST:
+        return 'R';
+      default:
+        throw AddressFormatException('Unknown network type');
+    }
+    return 'U';
+  }
+
+  /// Encodes the given bytes as an xaddress string.
+  String Encode() {
+    final checkBytes = _CreateChecksum(this);
+    final encodedPayload = _EncodePayload(this, checkBytes);
+    final outputAddress = StringBuffer();
+    outputAddress.write(prefix);
+    outputAddress.write(networkByte);
+    outputAddress.write(encodedPayload);
+    return outputAddress.toString();
+  }
+}
+
+List<int> _CreateChecksum(XAddress content) {
+  final buffer = BytesBuilder();
+  buffer.add(varintBufNum(content.prefix.runes.length));
+  buffer.add(List.from(content.prefix.runes));
+  buffer.addByte(content.networkByte.runes.first);
+  buffer.addByte(content.typeByte);
+  buffer.add(varintBufNum(content.payload.length));
+  buffer.add(content.payload);
+  final data = buffer.takeBytes();
+  final digest = sha256(data);
+  return digest.sublist(0, 4);
+}
+
+String _EncodePayload(XAddress content, List<int> checkBytes) {
+  final buffer = BytesBuilder();
+  buffer.addByte(content.typeByte);
+  buffer.add(content.payload);
+  buffer.add(checkBytes);
+  final bytes = buffer.takeBytes();
+  final encodedPayload = base58.encode(bytes);
+  return encodedPayload;
+}
+
+NetworkType _GetNetworkType(String network) {
+  switch (network) {
+    case '_':
+      return NetworkType.MAIN;
+    case 'T':
+      return NetworkType.TEST;
+    case 'R':
+      return NetworkType.REGTEST;
+    default:
+      throw AddressFormatException('Unknown network type');
+  }
+  return NetworkType.MAIN;
+}
+
+XAddressType _GetAddressType(int type) {
+  switch (type) {
+    case 0:
+      return XAddressType.ScriptPubKey;
+    default:
+      throw AddressFormatException('Unknown address type');
+  }
+  return XAddressType.ScriptPubKey;
+}

--- a/lib/lotus/xaddress_test.dart
+++ b/lib/lotus/xaddress_test.dart
@@ -1,0 +1,21 @@
+import 'package:test/test.dart';
+import 'dart:math';
+
+import 'xaddress.dart';
+import 'networks.dart';
+
+void main() {
+  test('can decode and encode XAddresses', () {
+    var random = Random.secure();
+    var values = List<int>.generate(20, (i) => random.nextInt(256));
+    final xaddress = XAddress(
+        network: NetworkType.MAIN,
+        type: XAddressType.ScriptPubKey,
+        payload: values);
+    final decodedXaddress = XAddress.Decode(xaddress.Encode());
+    expect(xaddress.prefix, decodedXaddress.prefix);
+    expect(xaddress.network, decodedXaddress.network);
+    expect(xaddress.type, decodedXaddress.type);
+    expect(xaddress.payload, decodedXaddress.payload);
+  });
+}


### PR DESCRIPTION
This commit adds support for XAddresses to the Lotus library. This
is part of the on-going work to move to the Lotus chain with the
Cashew -> Vase rebranding.