### PR TITLE
Reformat balance displays to XPI

### DIFF
--- a/lib/components/calculator_keyboard/calculator.dart
+++ b/lib/components/calculator_keyboard/calculator.dart
@@ -107,7 +107,7 @@ void evaluateExpression(List<String> stack) {
   stack.clear();
   assert(output.length < 2, 'Invalid output length');
   if (output.length == 1) {
-    stack.addAll(output.removeLast().truncate().toString().split(''));
+    stack.addAll(output.removeLast().toString().split(''));
   }
   stack.addAll(reversedStack.reversed);
   if (stack.isEmpty) {

--- a/lib/components/calculator_keyboard/keyboard.dart
+++ b/lib/components/calculator_keyboard/keyboard.dart
@@ -30,7 +30,7 @@ class CalculatorKeyboard extends StatelessWidget {
       final evaluatedStack = stack.sublist(0);
       evaluateExpression(evaluatedStack);
       final takenNumbers = takeNumbers(evaluatedStack.reversed.toList());
-      amount = takenNumbers.isNaN ? 0 : takenNumbers.truncate();
+      amount = takenNumbers.isNaN ? 0 : (takenNumbers * 1000000).truncate();
 
       // This will be mutated, that's why we need to update the value.
       dataNotifier.value =

--- a/lib/lotus/utils/format_amount.dart
+++ b/lib/lotus/utils/format_amount.dart
@@ -1,0 +1,9 @@
+String formatAmount(dynamic amount) {
+  if (amount is String) {
+    return amount;
+  }
+  if (amount < 1000000) {
+    return '$amount sats';
+  }
+  return '${amount / 1000000} XPI';
+}

--- a/lib/lotus/utils/parse_uri.dart
+++ b/lib/lotus/utils/parse_uri.dart
@@ -22,7 +22,7 @@ ParseURIResult parseSendURI(String uri) {
 
   int intAmount;
   if (amount.truncateToDouble() != amount) {
-    intAmount = (amount * 100000000).truncate();
+    intAmount = (amount * 1000000).truncate();
   } else {
     intAmount = amount.truncate();
   }

--- a/lib/tabs/component/balance_display.dart
+++ b/lib/tabs/component/balance_display.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import '../../wallet/wallet.dart';
 import '../../constants.dart';
+import '../../../lotus/utils/format_amount.dart';
 
 class BalanceDisplay extends StatelessWidget {
   final ValueNotifier<WalletBalance> balanceNotifier;
@@ -43,20 +44,12 @@ class BalanceDisplay extends StatelessWidget {
                       );
                     }
                     return Text.rich(TextSpan(
-                      text: '${balance.balance}',
+                      text: '${formatAmount(balance.balance)}',
                       style: TextStyle(
                         color: Colors.black,
                         fontWeight: FontWeight.bold,
                         fontSize: 17,
                       ),
-                      children: [
-                        TextSpan(
-                          text: ' sats',
-                          style: TextStyle(
-                              color: Colors.black.withOpacity(.8),
-                              fontSize: 15),
-                        ),
-                      ],
                     ));
                   }),
             ],

--- a/lib/tabs/component/payment_amount_display.dart
+++ b/lib/tabs/component/payment_amount_display.dart
@@ -2,8 +2,10 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+import '../../../lotus/utils/format_amount.dart';
+
 class PaymentAmountDisplay extends StatelessWidget {
-  final String amount;
+  final int amount;
   final String function;
   PaymentAmountDisplay({Key key, this.amount, this.function})
       : super(
@@ -25,7 +27,7 @@ class PaymentAmountDisplay extends StatelessWidget {
       Row(children: [
         Expanded(
             child: Text(
-          '= ${amount} sats',
+          '= ${formatAmount(amount)}',
           textAlign: TextAlign.right,
           style: TextStyle(
               fontSize: Theme.of(context).textTheme.headline5.fontSize,

--- a/lib/tabs/receive.dart
+++ b/lib/tabs/receive.dart
@@ -116,8 +116,7 @@ class ReceiveTab extends StatelessWidget {
               valueListenable: keyboardNotifier,
               builder: (context, CalculatorData balance, child) =>
                   PaymentAmountDisplay(
-                      amount: balance.amount.toString(),
-                      function: balance.function)),
+                      amount: balance.amount, function: balance.function)),
           calculatorKeyboard,
         ],
       ),

--- a/lib/tabs/send/send_info.dart
+++ b/lib/tabs/send/send_info.dart
@@ -88,7 +88,7 @@ class SendInfo extends StatelessWidget {
 
         // Use the unparsed version, so that it appears as it was originally copied
         sendModel.sendToAddress = parseResult.address ?? '';
-        sendModel.sendAmount = parseResult.amount;
+        sendModel.sendAmount = parseResult.amount ?? 0;
 
         keyboardNotifier.value = CalculatorData(
             amount: sendModel.sendAmount,
@@ -165,7 +165,7 @@ class SendInfo extends StatelessWidget {
                     child: Consumer<SendModel>(
                         builder: (context, viewModel, child) =>
                             PaymentAmountDisplay(
-                                amount: (viewModel.sendAmount ?? 0).toString(),
+                                amount: viewModel.sendAmount ?? 0,
                                 function:
                                     keyboardNotifier.value.function ?? '')))
               ]),


### PR DESCRIPTION
Rather than always showing sats, reformat to XPI with a decimal place
when applicable. In the future, this should be localized.