### PR TITLE
Move lotus library tests into a proper subfolder of the test directory

### DIFF
--- a/lib/lotus/encoding/ckdserializer.dart
+++ b/lib/lotus/encoding/ckdserializer.dart
@@ -53,8 +53,7 @@ abstract class CKDSerializer {
 
     // checksum calculation... doubleSha
     var doubleShaAddr = utils.sha256Twice(serializedKey);
-    var checksum =
-        doubleShaAddr.sublist(0, 4).map((elem) => elem.toSigned(8)).toList();
+    var checksum = doubleShaAddr.sublist(0, 4);
 
     return bs58check.encode(serializedKey + checksum);
   }

--- a/lib/lotus/privatekey.dart
+++ b/lib/lotus/privatekey.dart
@@ -6,10 +6,6 @@ import 'package:pointycastle/ecc/curves/secp256k1.dart';
 import 'package:pointycastle/api.dart';
 import 'package:pointycastle/pointycastle.dart';
 import 'package:pointycastle/random/fortuna_random.dart';
-// Use pointycastle asn1 bigint encode/decode. Does not include
-// padding for negative bigints numbers which is the needed encoding
-// for WIFs.
-import 'package:pointycastle/src/utils.dart';
 
 import 'address.dart';
 import 'exceptions.dart';
@@ -196,7 +192,7 @@ class BCHPrivateKey {
   /// Returns this Private Key in WIF format. See [toWIF()].
   String toWIF() {
     // convert private key _d to a hex string
-    var wifKey = encodeBigInt(_d).toList();
+    var wifKey = encodeUInt256(_d).toList();
     if (wifKey[0] == 0) {}
     if (_networkType == NetworkType.MAIN) {
       wifKey = [0x80] + wifKey;

--- a/test/lotus_test/address_test.dart
+++ b/test/lotus_test/address_test.dart
@@ -1,7 +1,7 @@
 import 'package:test/test.dart';
 import 'package:hex/hex.dart';
 
-import 'address.dart';
+import 'package:vase/lotus/address.dart';
 
 void main() {
   test('can decode and encode an address', () async {
@@ -45,7 +45,7 @@ void main() {
   });
 
   test('can decode from cashaddress and encode to xaddress', () async {
-    final xAddress = 'lotusT16PSJHU42xeYK54uebr811ZAdJ5LhsJRw92YAFVax';
+    final xAddress = 'lotusT16PSJHU42xeYK54uebr811ZAdJ5LhsJRw92WgNQfL';
     final cashaddr = 'bchtest:qq9e0r875ed2zmd6qe0kgsjxwjnadzrl9sukcatjha';
     var address = Address(cashaddr);
     expect(address.toXAddress(), xAddress);

--- a/test/lotus_test/cashaddress_test.dart
+++ b/test/lotus_test/cashaddress_test.dart
@@ -1,14 +1,13 @@
 import 'package:test/test.dart';
 
-import 'cashaddress.dart';
-import 'address.dart';
+import 'package:vase/lotus/cashaddress.dart';
+import 'package:vase/lotus/address.dart';
 
 void main() {
   test('can decode and encode to base58', () async {
-    final cashaddr = 'lotus:qqeht8vnwag20yv8dvtcrd4ujx09fwxwsqqqw93w88';
+    final cashaddr = 'bitcoincash:qqeht8vnwag20yv8dvtcrd4ujx09fwxwsqqqw93w88';
     final legacy = '15h6MrWynwLTwhhYWNjw1RqCrhvKv3ZBsi';
-    var address = Decode(cashaddr, 'lotus');
-
+    var address = Decode(cashaddr, 'bitcoincash');
     expect(
         Address.fromAddressBytes(address.addressBytes,
                 networkType: address.networkType,
@@ -18,8 +17,8 @@ void main() {
   });
 
   test('can decode and encode cashaddresses', () async {
-    final cashaddr = 'lotus:qqeht8vnwag20yv8dvtcrd4ujx09fwxwsqqqw93w88';
-    var address = Decode(cashaddr, 'lotus');
+    final cashaddr = 'bitcoincash:qqeht8vnwag20yv8dvtcrd4ujx09fwxwsqqqw93w88';
+    var address = Decode(cashaddr, 'bitcoincash');
     var encodedCashaddr = Encode(address);
 
     expect(encodedCashaddr, cashaddr);

--- a/test/lotus_test/encoding_test/base32_test.dart
+++ b/test/lotus_test/encoding_test/base32_test.dart
@@ -1,7 +1,7 @@
 import 'package:test/test.dart';
 import 'package:dartz/dartz.dart';
 
-import 'base32.dart';
+import 'package:vase/lotus/encoding/base32.dart';
 
 void main() {
   test('can encode to base32', () async {

--- a/test/lotus_test/encoding_test/converbits_test.dart
+++ b/test/lotus_test/encoding_test/converbits_test.dart
@@ -1,6 +1,6 @@
 import 'package:test/test.dart';
 
-import 'convertbits.dart';
+import 'package:vase/lotus/encoding/convertbits.dart';
 
 void main() {
   test('can convert back and forth between 8 and 5 bit format', () async {

--- a/test/lotus_test/hdprivatekey_test.dart
+++ b/test/lotus_test/hdprivatekey_test.dart
@@ -1,8 +1,8 @@
 import 'package:test/test.dart';
 
-import './hdprivatekey.dart';
-import './bip39/bip39.dart';
-import './networks.dart';
+import 'package:vase/lotus/hdprivatekey.dart';
+import 'package:vase/lotus/bip39/bip39.dart';
+import 'package:vase/lotus/networks.dart';
 
 const testSeed =
     'festival shrimp feel before tackle pyramid immense banner fire wash steel fiscal';
@@ -60,8 +60,7 @@ void main() {
               .toAddress()
               .toCashAddress(),
           address,
-          reason:
-              'Keynumber $keyNumber failed to check against test vectors');
+          reason: 'Keynumber $keyNumber failed to check against test vectors');
     });
 
     final masterChangeKey = masterAccountKey.deriveChildNumber(1);
@@ -85,8 +84,7 @@ void main() {
               .toAddress()
               .toCashAddress(),
           address,
-          reason:
-              'Keynumber $keyNumber failed to check against test vectors');
+          reason: 'Keynumber $keyNumber failed to check against test vectors');
     });
   });
 

--- a/test/lotus_test/hdpublickey_test.dart
+++ b/test/lotus_test/hdpublickey_test.dart
@@ -1,8 +1,8 @@
 import 'package:test/test.dart';
 
-import './hdprivatekey.dart';
-import './bip39/bip39.dart';
-import './networks.dart';
+import 'package:vase/lotus/hdprivatekey.dart';
+import 'package:vase/lotus/bip39/bip39.dart';
+import 'package:vase/lotus/networks.dart';
 
 const testSeed =
     'festival shrimp feel before tackle pyramid immense banner fire wash steel fiscal';
@@ -48,8 +48,7 @@ void main() {
               .toAddress()
               .toCashAddress(),
           address,
-          reason:
-              'Keynumber $keyNumber failed to check against test vectors');
+          reason: 'Keynumber $keyNumber failed to check against test vectors');
     });
 
     final masterChangeKey = masterAccountKey.deriveChildNumber(1).hdPublicKey;
@@ -73,8 +72,7 @@ void main() {
               .toAddress()
               .toCashAddress(),
           address,
-          reason:
-              'Keynumber $keyNumber failed to check against test vectors');
+          reason: 'Keynumber $keyNumber failed to check against test vectors');
     });
   });
 }

--- a/test/lotus_test/xaddress_test.dart
+++ b/test/lotus_test/xaddress_test.dart
@@ -1,8 +1,8 @@
 import 'package:test/test.dart';
 import 'dart:math';
 
-import 'xaddress.dart';
-import 'networks.dart';
+import 'package:vase/lotus/xaddress.dart';
+import 'package:vase/lotus/networks.dart';
 
 void main() {
   test('can decode and encode XAddresses', () {


### PR DESCRIPTION
In order to make tests run automatically from `flutter test` they need
to conform to the appropriate directory layout. Eventually, we want to
factor out the Lotus library into it's own published library, but for
now we will leave it as part of this project due to the need to iterate
on the APIs.