### PR TITLE
fix balance overflow and alignment

### DIFF
--- a/lib/tabs/component/balance_display.dart
+++ b/lib/tabs/component/balance_display.dart
@@ -1,9 +1,8 @@
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import '../../wallet/wallet.dart';
-import '../../constants.dart';
+
 import '../../../lotus/utils/format_amount.dart';
+import '../../constants.dart';
+import '../../wallet/wallet.dart';
 
 class BalanceDisplay extends StatelessWidget {
   final ValueNotifier<WalletBalance?> balanceNotifier;
@@ -19,41 +18,36 @@ class BalanceDisplay extends StatelessWidget {
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 15.0, vertical: 5.0),
           color: Colors.grey[400]!.withOpacity(0.6),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              ValueListenableBuilder<WalletBalance?>(
-                  valueListenable: balanceNotifier,
-                  builder: (context, balance, child) {
-                    if (balance != null && balance.error != null) {
-                      return Text(
-                        balance.error.toString(),
-                        style: TextStyle(
-                            color: Colors.red,
-                            fontWeight: FontWeight.bold,
-                            fontSize: 13),
-                      );
-                    }
-                    if (balance == null || balance.balance == null) {
-                      return Text(
-                        'Loading...',
-                        style: TextStyle(
-                            color: Colors.grey,
-                            fontWeight: FontWeight.bold,
-                            fontSize: 13),
-                      );
-                    }
-                    return Text.rich(TextSpan(
-                      text: '${formatAmount(balance.balance)}',
-                      style: TextStyle(
-                        color: Colors.black,
+          child: ValueListenableBuilder<WalletBalance?>(
+              valueListenable: balanceNotifier,
+              builder: (context, balance, child) {
+                if (balance != null && balance.error != null) {
+                  return Text(
+                    balance.error.toString(),
+                    style: TextStyle(
+                        color: Colors.red,
                         fontWeight: FontWeight.bold,
-                        fontSize: 17,
-                      ),
-                    ));
-                  }),
-            ],
-          ),
+                        fontSize: 13),
+                  );
+                }
+                if (balance == null || balance.balance == null) {
+                  return Text(
+                    'Loading...',
+                    style: TextStyle(
+                        color: Colors.grey,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 13),
+                  );
+                }
+                return Text.rich(TextSpan(
+                  text: '${formatAmount(balance.balance)}',
+                  style: TextStyle(
+                    color: Colors.black,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 17,
+                  ),
+                ));
+              }),
         ),
       ),
     );

--- a/lib/tabs/send/send.dart
+++ b/lib/tabs/send/send.dart
@@ -1,16 +1,17 @@
-import 'package:vase/lotus/utils/parse_uri.dart';
-import 'package:vase/viewmodel.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter/foundation.dart';
-import 'package:provider/provider.dart';
 import 'dart:core';
 
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:qr_code_scanner/qr_code_scanner.dart';
+import 'package:vase/lotus/utils/parse_uri.dart';
+import 'package:vase/viewmodel.dart';
 
-import './send_info.dart';
 import './sendModel.dart';
-import '../component/balance_display.dart';
+import './send_info.dart';
+import '../../constants.dart';
 import '../../lotus/utils/parse_uri.dart';
+import '../component/balance_display.dart';
 
 class SendTab extends StatefulWidget {
   final PageController controller;
@@ -33,6 +34,7 @@ class _SendTabState extends State<SendTab> {
 
   @override
   Widget build(BuildContext context) {
+    final topPadding = MediaQuery.of(context).padding.top;
     var screenDimension = MediaQuery.of(context).size;
 
     // WE don't want to be redrawing
@@ -98,8 +100,11 @@ class _SendTabState extends State<SendTab> {
                   )),
         ),
         Positioned(
-          top: screenDimension.height * .1,
-          child: BalanceDisplay(balanceNotifier: balanceNotifier),
+          top: topPadding,
+          child: Container(
+              constraints: BoxConstraints(maxWidth: screenDimension.width),
+              padding: stdPadding,
+              child: BalanceDisplay(balanceNotifier: balanceNotifier)),
         ),
         Positioned(
           bottom: 35.0,


### PR DESCRIPTION
- fixed balance view on main tab being unbounded and not aligned with the other tabs
- removed unnecessary `Row` widget
- positioned balance display with a constrained container offset by the padding of the toolbar (similar to safearea)