### PR TITLE
Add simple socket error message

### DIFF
--- a/lib/tabs/component/balance_display.dart
+++ b/lib/tabs/component/balance_display.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 import '../../../lotus/utils/format_amount.dart';
@@ -21,9 +23,10 @@ class BalanceDisplay extends StatelessWidget {
           child: ValueListenableBuilder<WalletBalance?>(
               valueListenable: balanceNotifier,
               builder: (context, balance, child) {
-                if (balance != null && balance.error != null) {
+                final error = balance?.error;
+                if (error != null) {
                   return Text(
-                    balance.error.toString(),
+                    showFriendlyError(error),
                     style: TextStyle(
                         color: Colors.red,
                         fontWeight: FontWeight.bold,
@@ -52,4 +55,12 @@ class BalanceDisplay extends StatelessWidget {
       ),
     );
   }
+}
+
+String showFriendlyError(Exception error) {
+  if (error is SocketException) {
+    return 'Error connecting to the network. Please restart the app.';
+  }
+
+  return error.toString();
 }

--- a/lib/wallet/wallet.dart
+++ b/lib/wallet/wallet.dart
@@ -132,7 +132,6 @@ class Wallet {
       await updateUtxos(client: client);
     } catch (err) {
       print(err);
-      print("ERROR");
       updateBalance(WalletBalance(balance: null, error: err as Exception?));
       return;
     }


### PR DESCRIPTION
- Added a friendly message to replace the standard socket error message which originally was:

**Old**
```
SocketException: HTTP connection timed out after 0:00:01.000000, host: fulcrum.cashweb.io, port: 443
```

**New**
```
Error connecting to the network. Please restart the app.
```

- Remove an extraneous log
