### PR TITLE
Show errors only on send

### DIFF
--- a/lib/tabs/send/sendModel.dart
+++ b/lib/tabs/send/sendModel.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 class SendModel with ChangeNotifier {
   int? _sendAmount;
   String? _sendToAddress;
+  List<String> _errors = [];
 
   // TODO: Storage should be injected
   SendModel() {
@@ -10,17 +11,24 @@ class SendModel with ChangeNotifier {
     _sendAmount = null;
   }
 
+  int? get sendAmount => _sendAmount;
+
+  String? get sendToAddress => _sendToAddress;
+
+  List<String> get errors => _errors;
+
+  set sendToAddress(String? newValue) {
+    _sendToAddress = newValue;
+    notifyListeners();
+  }
+
   set sendAmount(int? newValue) {
     _sendAmount = newValue;
     notifyListeners();
   }
 
-  int? get sendAmount => _sendAmount;
-
-  String? get sendToAddress => _sendToAddress;
-
-  set sendToAddress(String? newValue) {
-    _sendToAddress = newValue;
+  set errors(List<String> newValue) {
+    _errors = newValue;
     notifyListeners();
   }
 }

--- a/lib/tabs/send/send_info.dart
+++ b/lib/tabs/send/send_info.dart
@@ -67,8 +67,6 @@ class SendInfo extends StatefulWidget {
 }
 
 class _SendInfoState extends State<SendInfo> {
-  var errors = [];
-
   @override
   Widget build(context) {
     final walletModel = Provider.of<WalletModel>(context, listen: false);
@@ -78,8 +76,9 @@ class _SendInfoState extends State<SendInfo> {
         ValueNotifier<CalculatorData>(CalculatorData(amount: 0, function: ''));
 
     keyboardNotifier.addListener(() {
+      print('${keyboardNotifier.value.amount}');
       sendModel.sendAmount = keyboardNotifier.value.amount;
-      errors = [];
+      sendModel.errors = [];
     });
 
     void sendTransaction(BuildContext context, String address, int amount) {
@@ -137,7 +136,7 @@ class _SendInfoState extends State<SendInfo> {
               return Column(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
-                  if (errors.isNotEmpty)
+                  if (viewModel.errors.isNotEmpty)
                     Text(
                       'Not able to send:',
                       textAlign: TextAlign.center,
@@ -146,7 +145,7 @@ class _SendInfoState extends State<SendInfo> {
                           color: Colors.red,
                           fontSize: 15),
                     ),
-                  for (final error in errors)
+                  for (final error in viewModel.errors)
                     RichText(
                       textAlign: TextAlign.center,
                       text: TextSpan(
@@ -164,16 +163,14 @@ class _SendInfoState extends State<SendInfo> {
                       Expanded(
                         child: ElevatedButton(
                           autofocus: true,
-                          onPressed: errors.isEmpty
+                          onPressed: viewModel.errors.isEmpty
                               ? () {
                                   final errs = canSend(
                                       viewModel.sendAmount ?? 0,
                                       viewModel.sendToAddress ?? '',
                                       walletModel.balance.value!.balance ?? 0);
 
-                                  setState(() {
-                                    errors = errs;
-                                  });
+                                  viewModel.errors = errs;
 
                                   if (errs.isEmpty) {
                                     sendTransaction(

--- a/lib/tabs/send/send_info.dart
+++ b/lib/tabs/send/send_info.dart
@@ -67,7 +67,6 @@ class SendInfo extends StatefulWidget {
 }
 
 class _SendInfoState extends State<SendInfo> {
-  var submitted = false;
   var errors = [];
 
   @override

--- a/lib/tabs/send/send_info.dart
+++ b/lib/tabs/send/send_info.dart
@@ -16,15 +16,17 @@ import '../../lotus/transaction/transaction.dart';
 import '../component/payment_amount_display.dart';
 import '../component/balance_display.dart';
 
+const MIN_SATS = 1024;
+
 List<String> canSend(int amount, String address, int balance) {
   final errors = <String>[];
 
-  if (amount < 1024) {
-    errors.add('Amount too low');
+  if (amount < MIN_SATS) {
+    errors.add('Minimum send amount is $MIN_SATS satoshi');
   }
 
   if (amount > balance) {
-    errors.add('Insufficient funds');
+    errors.add('Wallet balance too low');
   }
 
   try {
@@ -57,21 +59,28 @@ Future showError(BuildContext context, String errMessage) {
       });
 }
 
-class SendInfo extends StatelessWidget {
-  final ValueNotifier<CalculatorData> keyboardNotifier;
+class SendInfo extends StatefulWidget {
+  SendInfo({Key? key});
 
-  SendInfo({Key? key})
-      : keyboardNotifier = ValueNotifier<CalculatorData>(
-            CalculatorData(amount: 0, function: ''));
+  @override
+  State<SendInfo> createState() => _SendInfoState();
+}
+
+class _SendInfoState extends State<SendInfo> {
+  var submitted = false;
+  var errors = [];
 
   @override
   Widget build(context) {
     final walletModel = Provider.of<WalletModel>(context, listen: false);
     final balanceNotifier = walletModel.balance;
     final sendModel = Provider.of<SendModel>(context, listen: false);
+    final keyboardNotifier =
+        ValueNotifier<CalculatorData>(CalculatorData(amount: 0, function: ''));
 
     keyboardNotifier.addListener(() {
       sendModel.sendAmount = keyboardNotifier.value.amount;
+      errors = [];
     });
 
     void sendTransaction(BuildContext context, String address, int amount) {
@@ -122,85 +131,75 @@ class SendInfo extends StatelessWidget {
         ),
       ),
       body: Padding(
-          padding: stdPadding,
-          child: SafeArea(
-              child: Column(
-            children: [
-              Expanded(child:
-                  Consumer<SendModel>(builder: (context, viewModel, child) {
-                final errors = canSend(
-                    viewModel.sendAmount ?? 0,
-                    viewModel.sendToAddress ?? '',
-                    walletModel.balance.value!.balance ?? 0);
-                return Column(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    crossAxisAlignment: CrossAxisAlignment.end,
+        padding: stdPadding,
+        child: SafeArea(
+          child: Consumer<SendModel>(
+            builder: (context, viewModel, child) {
+              return Column(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  if (errors.isNotEmpty)
+                    Text(
+                      'Not able to send:',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          color: Colors.red,
+                          fontSize: 15),
+                    ),
+                  for (final error in errors)
+                    RichText(
+                      textAlign: TextAlign.center,
+                      text: TextSpan(
+                        text: error,
+                        style: TextStyle(color: Colors.red, fontSize: 15),
+                      ),
+                    ),
+                  BalanceDisplay(balanceNotifier: balanceNotifier),
+                  AddressDisplay(onTap: pasteAddress),
+                  PaymentAmountDisplay(
+                      amount: viewModel.sendAmount ?? 0,
+                      function: keyboardNotifier.value.function ?? ''),
+                  Row(
                     children: [
-                      errors.isEmpty
-                          ? <Widget>[]
-                          : [
-                              Row(children: [
-                                Expanded(
-                                    child: Text('Not able to send:',
-                                        textAlign: TextAlign.center,
-                                        style: TextStyle(
-                                            fontWeight: FontWeight.bold,
-                                            color: Colors.red,
-                                            fontSize: 15)))
-                              ])
-                            ],
-                      errors
-                          .map((errorText) => Row(children: [
-                                Expanded(
-                                    child: RichText(
-                                  textAlign: TextAlign.center,
-                                  text: TextSpan(
-                                    text: errorText,
-                                    style: TextStyle(
-                                        color: Colors.red, fontSize: 15),
-                                  ),
-                                ))
-                              ]))
-                          .toList()
-                    ].expand((row) => row).toList());
-              })),
-              BalanceDisplay(balanceNotifier: balanceNotifier),
-              AddressDisplay(onTap: pasteAddress),
-              Row(children: [
-                Expanded(
-                    child: Consumer<SendModel>(
-                        builder: (context, viewModel, child) =>
-                            PaymentAmountDisplay(
-                                amount: viewModel.sendAmount ?? 0,
-                                function:
-                                    keyboardNotifier.value.function ?? '')))
-              ]),
-              Consumer<SendModel>(builder: (context, viewModel, child) {
-                final errors = canSend(
-                    viewModel.sendAmount ?? 0,
-                    viewModel.sendToAddress ?? '',
-                    walletModel.balance.value!.balance ?? 0);
-                return Row(children: [
-                  Expanded(
-                      child: ElevatedButton(
-                    autofocus: true,
-                    onPressed: errors.isEmpty
-                        ? () {
-                            sendTransaction(context, viewModel.sendToAddress!,
-                                viewModel.sendAmount!);
-                          }
-                        : null,
-                    child: Text('Send'),
-                  ))
-                ]);
-              }),
-              CalculatorKeyboard(
-                  dataNotifier: keyboardNotifier,
-                  initialValue: (sendModel.sendAmount ?? '').toString()),
-              // Confirm Amount button widget writes to global SendModel
-              // and then switches to Slide to send button:
-            ],
-          ))),
+                      Expanded(
+                        child: ElevatedButton(
+                          autofocus: true,
+                          onPressed: errors.isEmpty
+                              ? () {
+                                  final errs = canSend(
+                                      viewModel.sendAmount ?? 0,
+                                      viewModel.sendToAddress ?? '',
+                                      walletModel.balance.value!.balance ?? 0);
+
+                                  setState(() {
+                                    errors = errs;
+                                  });
+
+                                  if (errs.isEmpty) {
+                                    sendTransaction(
+                                        context,
+                                        viewModel.sendToAddress!,
+                                        viewModel.sendAmount!);
+                                  }
+                                }
+                              : null,
+                          child: Text('Send'),
+                        ),
+                      ),
+                    ],
+                  ),
+                  if (child != null) child
+                ],
+              );
+            },
+            child: CalculatorKeyboard(
+              dataNotifier: keyboardNotifier,
+              initialValue: '${sendModel.sendAmount ?? ''}',
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/tabs/send/send_info.dart
+++ b/lib/tabs/send/send_info.dart
@@ -59,14 +59,7 @@ Future showError(BuildContext context, String errMessage) {
       });
 }
 
-class SendInfo extends StatefulWidget {
-  SendInfo({Key? key});
-
-  @override
-  State<SendInfo> createState() => _SendInfoState();
-}
-
-class _SendInfoState extends State<SendInfo> {
+class SendInfo extends StatelessWidget {
   @override
   Widget build(context) {
     final walletModel = Provider.of<WalletModel>(context, listen: false);
@@ -76,7 +69,6 @@ class _SendInfoState extends State<SendInfo> {
         ValueNotifier<CalculatorData>(CalculatorData(amount: 0, function: ''));
 
     keyboardNotifier.addListener(() {
-      print('${keyboardNotifier.value.amount}');
       sendModel.sendAmount = keyboardNotifier.value.amount;
       sendModel.errors = [];
     });


### PR DESCRIPTION
Updated the send screen to only show errors when the send button is pressed and to clear them after additional input. This removes the errors showing as soon as the screen opens
Updated some error message text

|Start|End|
|-|-|
|![Simulator Screen Shot - iPhone 13 - 2022-01-09 at 07 36 37](https://user-images.githubusercontent.com/4146037/148682460-6b80f37c-b189-4a6f-9747-1c5a0212d960.png)|![Simulator Screen Shot - iPhone 13 - 2022-01-09 at 05 50 02](https://user-images.githubusercontent.com/4146037/148682474-b6e1450d-145c-4726-aa44-577e1fdf5357.png)|